### PR TITLE
管理メニューから不要な表記を削除し、スマホプレビューボタンを追加する

### DIFF
--- a/lib/qhm_init.php
+++ b/lib/qhm_init.php
@@ -269,19 +269,10 @@ EOD;
 			'qblognewlink' => array('name'=>'記事の追加', 'link'=>$script.'?cmd=qblog&mode=addpost', 'style'=>'', 'class'=>'', 'visible'=>TRUE),
 		)
 	),
-	'haiklink' => array(
-		'name'    => 'テーマ',
-		'link'    => '',
-		'style'   => 'margin-top:1.1em;',
-		'class'   => '',
-		'visible' => true,
-		'sub'     => array(
-			'haikskincustomizer' => array('name'=>'編集', 'link'=>$link_haik_skin_customizer, 'style'=>'', 'class'=>'', 'visible'=>TRUE),
-			'haikpreviewlink' => array('name'=>'<span class="hidden-xs hidden-sm"><i class="glyphicon glyphicon-phone"></i> <span class="sr-only">モバイル</span>プレビュー</span>', 'link'=>'#', 'style'=>'', 'class' => '', 'visible'=>TRUE),
-		),
-	),
+	'haikskincustomizer' => array('name'=>'テーマ編集', 'link'=>$link_haik_skin_customizer, 'style'=>'margin-top:1.1em;', 'class'=>'', 'visible'=>TRUE),
+	'haikpreviewlink' => array('name'=>'<span class="hidden-xs hidden-sm"><i class="glyphicon glyphicon-phone"></i> <span class="sr-only">モバイル</span>プレビュー</span>', 'link'=>'#', 'style'=>'', 'class' => '', 'visible'=>TRUE),
 	'configlink' => array('name'=>$qm->m['qhm_init']['configlink_name'], 'link'=>$link_qhm_setting, 'style'=>'margin-top:1.1em;', 'visible'=>true, 'sub'=>array()),
-	'helplink'   => array('name'=>'open-qhm.net', 'link'=>$link_help, 'style'=>'', 'visible'=>true, 'sub'=>array()),
+// 	'helplink'   => array('name'=>'open-qhm.net', 'link'=>$link_help, 'style'=>'', 'visible'=>true, 'sub'=>array()),
 	'passwordlink'   => array('name'=>$qm->m['qhm_init']['passwordlink_name'], 'link'=>$link_password, 'style'=>'', 'visible'=>true, 'sub'=>array()),
 	'logoutlink' => array('name'=>$qm->m['qhm_init']['logoutlink_name'], 'link'=>$link_qhm_logout, 'style'=>'margin-top:1.1em;', 'visible'=>true, 'sub'=>array()),
 	'updatelink' => array('name'=>$qm->m['qhm_init']['updatelink_name'], 'link'=>$link_qhm_update, 'style'=>'margin-top:1.1em;', 'visible'=>true, 'sub'=>array()),
@@ -377,7 +368,8 @@ EOD;
 	}
 	if (strpos($style_name, 'haik_') !== 0)
 	{
-		if (isset($tools['haiklink'])) unset($tools['haiklink']);
+		if (isset($tools['haikskincustomizer'])) unset($tools['haikskincustomizer']);
+		if (isset($tools['haikpreviewlink'])) unset($tools['haikpreviewlink']);
 	}
 	else
 	{
@@ -403,7 +395,8 @@ EOD;
         if (isset($tools['toollink'])) unset($tools['toollink']);
         if (isset($tools['configlink'])) unset($tools['configlink']);
         if (isset($tools['helplink'])) unset($tools['helplink']);
-        if (isset($tools['haiklink'])) unset($tools['haiklink']);
+				if (isset($tools['haikskincustomizer'])) unset($tools['haikskincustomizer']);
+				if (isset($tools['haikpreviewlink'])) unset($tools['haikpreviewlink']);
     }
 	else {
 		if (isset($tools['passwordlink'])) unset($tools['passwordlink']);


### PR DESCRIPTION
WIP for #10 

----

## 期待する結果
管理メニューからopen-qhm.netの表記が削除され、かわりにスマホプレビューボタンが追加される

## すべきこと
- [x] open-qhm.net表記をなくす（AdminメニューのHTMLソースから削除する）
- [x] `テーマ`となっているものを`テーマ編集`と`スマホプレビュー`に分けて管理メニューに表示する

resolve #10 
