### PR TITLE
dlexecの脆弱性への対応

### DIFF
--- a/lib/init.php
+++ b/lib/init.php
@@ -11,7 +11,7 @@
 // PukiWiki version / Copyright / Licence
 
 define('S_VERSION', '1.4.7');
-define('QHM_VERSION', '6.0.8');  //絶対に編集しないで下さい
+define('QHM_VERSION', '6.0.9');  //絶対に編集しないで下さい
 define('QHM_OPTIONS', 'update=download; support=false; banner=true');
 define('S_COPYRIGHT',
 	'powered by <strong><a href="http://www.open-qhm.net/">QHM</a> ' . QHM_VERSION . '</strong> haik<br />' .

--- a/plugin/dlexec.php
+++ b/plugin/dlexec.php
@@ -139,7 +139,7 @@ function validate_downloadable_path() {
 	global $downloadable_path;
 	$cwd = getcwd();
 	$paths = array_filter(explode(';', $downloadable_path), 'strlen');
-	$result = true;
+	$result = TRUE;
 	
 	if (count($paths) === 0) {
 		$result = FALSE;
@@ -176,7 +176,6 @@ function canonicalize_path($path, $cwd=null){
   if (substr($path, 0, 1) === "/") {
     $filename = $path;
   }
-
   // prefix relative path with $root
   else {
     $root      = is_null($cwd) ? getcwd() : $cwd;

--- a/plugin/dlexec.php
+++ b/plugin/dlexec.php
@@ -53,6 +53,7 @@ download($key);
 
 function download($auth_key){
 
+	global $downloadable_path;
 	$qm = get_qm();
 
 	$filename = isset($_GET['filename']) ? $_GET['filename'] : '';
@@ -62,11 +63,19 @@ function download($auth_key){
 	$page     = isset($_GET['refer'])    ? $_GET['refer']    : '';
 
 	$filename = urldecode($filename);
+	$pathinfo  = pathinfo($filename);
+	$downloadable_path_array = explode(";", $downloadable_path);
 
 	//validate
 	$wikifile = 'wiki/'. encode($page) . '.txt';
 	$source = file_exists($wikifile) ? file_get_contents($wikifile) : '';
 
+	if(! in_array($pathinfo['dirname'], $downloadable_path_array, true))
+	{
+		header('HTTP/1.1 403 Forbidden');
+		error_msg('Error : Invalid access');
+		exit;
+	}
 	if ($page === '' OR ! preg_match('/&dl(?:button|link)\('. preg_quote($filename, '/').'(?:,|\))/', $source))
 	{
 		header('HTTP/1.1 403 Forbidden');

--- a/plugin/dlexec.php
+++ b/plugin/dlexec.php
@@ -43,6 +43,7 @@ if( file_exists('lib/qdsmtp.php') ){
 *********************************************/
 
 $key = md5( file_get_contents('qhm.ini.php') );
+validate_downloadable_path();
 download($key);
 
 
@@ -127,12 +128,77 @@ function download($auth_key){
 
 }
 
-function is_downloadable_file($filename){
+function is_downloadable_file($filename) {
 	global $downloadable_path;
 	$pathinfo  = pathinfo($filename);
-	$paths = explode(";", $downloadable_path);
+	$paths = array_filter(explode(";", $downloadable_path), 'strlen');
 	return in_array($pathinfo['dirname'], $paths, true);
 }
+
+function validate_downloadable_path() {
+	global $downloadable_path;
+	$cwd = getcwd();
+	$paths = array_filter(explode(';', $downloadable_path), 'strlen');
+	$result = true;
+	
+	if (count($paths) === 0) {
+		$result = FALSE;
+	}
+	
+	foreach ($paths as $path) {
+		$canonicalized_path = canonicalize_path($path, $cwd);
+		if ($canonicalized_path !== FALSE) {
+			if ($canonicalized_path === $cwd) {
+				// インストールディレクトリ直下なのでNG
+				$result = FALSE;
+			} else if (strpos($canonicalized_path, $cwd) === 0) {
+				// インストールディレクトリ以下なのでOK
+			} else {
+				// インストールディレクトリ以下ではない
+				$result = FALSE;
+			}
+		} else {
+			// 指定されたパスに権限がない、あるいは存在しない
+			$result = FALSE;
+		}
+	}
+
+	if ($result === FALSE) {
+		header('HTTP/1.1 500 Internal Server Error');
+		error_msg('Error : Invalid Configuration');
+		exit;
+	}
+}
+
+function canonicalize_path($path, $cwd=null){
+
+  // don't prefix absolute paths
+  if (substr($path, 0, 1) === "/") {
+    $filename = $path;
+  }
+
+  // prefix relative path with $root
+  else {
+    $root      = is_null($cwd) ? getcwd() : $cwd;
+    $filename  = sprintf("%s/%s", $root, $path);
+  }
+
+  // get realpath of dirname
+  $dirname   = dirname($filename);
+  $canonical = realpath($dirname);
+
+  // return FALSE if $dirname is nonexistent
+  if ($canonical === false) {
+    return FALSE;
+  }
+
+  // prevent double slash "//" below
+  if ($canonical === "/") $canonical = null;
+
+  // return canonicalized path
+  return sprintf("%s/%s", $canonical, basename($filename));
+}
+
 
 function dl_sendmail($email, $filename, $title){
 

--- a/plugin/dlexec.php
+++ b/plugin/dlexec.php
@@ -53,7 +53,6 @@ download($key);
 
 function download($auth_key){
 
-	global $downloadable_path;
 	$qm = get_qm();
 
 	$filename = isset($_GET['filename']) ? $_GET['filename'] : '';
@@ -63,14 +62,12 @@ function download($auth_key){
 	$page     = isset($_GET['refer'])    ? $_GET['refer']    : '';
 
 	$filename = urldecode($filename);
-	$pathinfo  = pathinfo($filename);
-	$downloadable_path_array = explode(";", $downloadable_path);
 
 	//validate
 	$wikifile = 'wiki/'. encode($page) . '.txt';
 	$source = file_exists($wikifile) ? file_get_contents($wikifile) : '';
 
-	if(! in_array($pathinfo['dirname'], $downloadable_path_array, true))
+	if(! is_downloadable_file($filename))
 	{
 		header('HTTP/1.1 403 Forbidden');
 		error_msg('Error : Invalid access');
@@ -128,6 +125,13 @@ function download($auth_key){
 
 	exit();
 
+}
+
+function is_downloadable_file($filename){
+	global $downloadable_path;
+	$pathinfo  = pathinfo($filename);
+	$paths = explode(";", $downloadable_path);
+	return in_array($pathinfo['dirname'], $paths, true);
 }
 
 function dl_sendmail($email, $filename, $title){

--- a/pukiwiki.ini.php
+++ b/pukiwiki.ini.php
@@ -160,6 +160,8 @@ $modifierlink = 'http://www.example.co.jp/'; // Site admin's Web page
 $googlemaps_apikey = 'ABQIAAAAiGS5xMxFoCjNEIdoMGiCBRSh3wgB-evfR4k_uhb9NTlXTFSqGRScvANPOtehBVz7qEVDLEwY4PlLng';
 // Fit videos to screen
 $enable_fitvids = true;
+// Downloadable path
+$downloadable_path = 'pub';
 
 
 $mobile_redirect = '';	// Mobile Access Redirect

--- a/pukiwiki.ini.php
+++ b/pukiwiki.ini.php
@@ -161,7 +161,7 @@ $googlemaps_apikey = 'ABQIAAAAiGS5xMxFoCjNEIdoMGiCBRSh3wgB-evfR4k_uhb9NTlXTFSqGR
 // Fit videos to screen
 $enable_fitvids = true;
 // Downloadable path
-$downloadable_path = 'pub';
+$downloadable_path = 'swfu/d;pub';
 
 
 $mobile_redirect = '';	// Mobile Access Redirect

--- a/pukiwiki.ini.php
+++ b/pukiwiki.ini.php
@@ -160,7 +160,7 @@ $modifierlink = 'http://www.example.co.jp/'; // Site admin's Web page
 $googlemaps_apikey = 'ABQIAAAAiGS5xMxFoCjNEIdoMGiCBRSh3wgB-evfR4k_uhb9NTlXTFSqGRScvANPOtehBVz7qEVDLEwY4PlLng';
 // Fit videos to screen
 $enable_fitvids = true;
-// Downloadable path
+// Downloadable path delimitered semicolon (;)
 $downloadable_path = 'swfu/d;pub';
 
 


### PR DESCRIPTION
# 概要
* Closes #27 , closes #28 
* ユーザーからの`&dllink`や`&dlbutton`のコメント投稿によってサーバー上の任意のファイルをダウンロードできる脆弱性への対応
* 管理者が指定したフォルダ以下のファイルのみダウンロードが可能（デフォルトは`swfu/d`  `pub`）
* 管理者が許可したファイル拡張子のファイルのみダウンロードが可能
* コメント投稿で`&dllink` `&dlbutton` の投稿を禁止

# テスト方法

not yet.

# TODO

- [x] 開発
- [x] レビュー
- [x] パッチバージョンUP
- [ ] マージ