### PR TITLE
[plugin]show でサイズ指定時に比率を保持して縮小し、収まらければ切り取る

### DIFF
--- a/plugin/show.inc.php
+++ b/plugin/show.inc.php
@@ -233,6 +233,8 @@ function plugin_show_body($args)
 		'normal'    => FALSE, //画像へのリンクを付ける
 		'linkurl'   => FALSE, //greybox, lightbox2, normal のリンク先
 		'label'     => FALSE, //labelを指定すると強制的に表示をlabelにする(greybox, lightbox2想定)。画像ファイルを指定するとそれを表示する。
+		'crop'      => TRUE,  // sizeを指定した場合、それに収まるようにトリミングされる (object-fit: cover)
+		'nocrop'    => FALSE, // crop の効果を無効にする
 		'noimg'     => FALSE, // 画像を展開しない
 		'zoom'      => FALSE, // 縦横比を保持する
 		'change'    => FALSE, // マウスオーバーで、画像を切り替える
@@ -408,6 +410,15 @@ function plugin_show_body($args)
 		} else {
 			$width  = $params['_w'] ? $params['_w'] : $width;
 			$height = $params['_h'] ? $params['_h'] : $height;
+		}
+
+		// 指定したサイズに合わせて切り取るかどうか
+		if ($params['nocrop']) {
+			$params['crop'] = FALSE;
+		}
+		if ($params['crop']) {
+			$params['class'] .= ' qhm-show-crop';
+			plugin_show_set_crop_style();
 		}
 	}
 	if ($params['_%']) {
@@ -1114,5 +1125,18 @@ $(document).on("ready", QHM.keepRatio);
 EOS;
 
 	$qt->appendv_once('plugin_show_set_keep_ratio', 'beforescript', $addjs);
+}
 
+function plugin_show_set_crop_style()
+{
+	$qt = get_qt();
+	$addstyle = <<< EOS
+<style>
+.qhm-show-crop {
+  object-fit: cover;
+}
+</style>
+EOS;
+
+	$qt->appendv_once('plugin_show_set_crop_style', 'beforescript', $addstyle);
 }


### PR DESCRIPTION
## 概要

* `show` プラグインを改良し、デフォルト動作を変更した ❗️ 
* 今まで：サイズを指定した場合、元ファイルの縦横比と指定したサイズが異なると比率が壊れて画像が見苦しいものになっていた
* 以後：縦横比を維持して縮小し、はみ出た部分は切り取られるようになる
* 従来の動作（縦横比無視して縮小）に戻すための `nocrop` オプションも追加した

## テスト方法

* IE/edge 以外でテストすること
* 管理者ログインし、適当なページの編集画面にしておくこと

1. 長方形の画像を添付する
2. `&show` で貼り付ける
3. 適当にサイズを指定する e.g.  `&show(filename.jpg,300x300,title);`
4. 更新
5. 正方形の画像が表示されていることを確認
6. 用意した画像が歪んでいないことを確認


## どうやって実装したのか？

CSS の `object-fit` プロパティを使っただけ。

[ブラウザ対応状況](http://caniuse.com/#search=object-fit)。IE/edge 以外の主要ブラウザで効果が得られる。

<img width="1255" alt="2016-12-18 0 13 49" src="https://cloud.githubusercontent.com/assets/808888/21287789/e4714dda-c4b6-11e6-8df6-5fe13ae33026.png">

IE/edge 対応をしていないので正直PRするか迷ったけど、せっかく実装したのでしときます。
スマホメインのサイトなら役に立つこともあるかと 😅 
全然 reject してくれて構わないです！

## スクリーンショット

<img width="622" alt="2016-12-18 0 23 48" src="https://cloud.githubusercontent.com/assets/808888/21287858/48d20520-c4b8-11e6-9d26-66980fc2a0c0.png">

<img width="629" alt="2016-12-18 0 24 13" src="https://cloud.githubusercontent.com/assets/808888/21287863/57cab108-c4b8-11e6-9fd3-08a30b66aff9.png">

<img width="625" alt="2016-12-18 0 25 28" src="https://cloud.githubusercontent.com/assets/808888/21287876/8dd983e6-c4b8-11e6-976a-f918952c7317.png">

## タスク

- [ ] レビュー
- [ ] バージョンアップ
- :shipit: 
