### PR TITLE
QBlogのPing送信機能を修正

### DIFF
--- a/plugin/qblog.inc.php
+++ b/plugin/qblog.inc.php
@@ -1241,20 +1241,20 @@ function plugin_qblog_update_ping()
 	$enable_ping = $vars['qblog_enable_ping'];
 	$pingstr = $vars['ping'];
 
-	//フラグ保存
-	if (exist_plugin("qhmsetting"))
-	{
-		$params = array();
-		$params['qblog_enable_ping'] = $enable_ping;
-		$_SESSION['qhmsetting'] = $params;
-		plugin_qhmsetting_update_ini();
-
-		$vars['phase'] = 'ping';
-		$qblog_enable_ping = $enable_ping;
-	}
+	$params = array();
+	$params['qblog_enable_ping'] = $enable_ping;
+	$vars['phase'] = 'ping';
+	$qblog_enable_ping = $enable_ping;
 
 	if ( ! $enable_ping)
 	{
+		if (exist_plugin("qhmsetting"))
+		{
+			$_SESSION['qhmsetting'] = $params;
+			plugin_qhmsetting_update_ini();
+
+			$vars['phase'] = 'ping';
+		}
 		return array('msg'=>'', 'body'=>'');
 	}
 
@@ -1267,7 +1267,6 @@ function plugin_qblog_update_ping()
 		//ping 保存
 		if (exist_plugin("qhmsetting"))
 		{
-			$params = array();
 			$params['qblog_ping'] = $pingstr;
 			$_SESSION['qhmsetting'] = $params;
 			plugin_qhmsetting_update_ini();
@@ -1277,9 +1276,7 @@ function plugin_qblog_update_ping()
 			//ping 送信
 			send_qblog_ping();
 		}
-
 	}
-
 
 	return array('msg'=>'', 'body'=>'');
 

--- a/plugin/qblog.inc.php
+++ b/plugin/qblog.inc.php
@@ -1221,16 +1221,13 @@ function plugin_qblog_rename_category()
 function plugin_qblog_get_default_ping()
 {
 	$ping = <<< EOP
-http://api.my.yahoo.co.jp/RPC2
 http://blog.goo.ne.jp/XMLRPC
 http://blogsearch.google.co.jp/ping/RPC2
 http://ping.bloggers.jp/rpc/
 http://ping.blogranking.net/
 http://ping.fc2.com/
 http://ping.namaan.net/rpc/
-http://ping.rss.drecom.jp/
 http://pingoo.jp/ping/
-http://rpc.reader.livedoor.com/ping
 EOP;
 	return trim($ping);
 }


### PR DESCRIPTION
Close #47 
Close #48 

## 概要

* PHP5.6 以降で設定画面においてQBlog の Ping 送信を有効化できない問題を修正
* 一度のリクエスト内にセッションの更新が複数回あったことが原因
    * `plugin_qhmsetting_update_ini` はセッション連想配列の読み込み/書き込み/削除を行っている関数のため、複数回呼び出すとセッションファイルに書き出すところで不整合が出そう（適当）
* デフォルトのPing先に死んだホストがいくつかあり、タイムアウトが発生するため、設定やブログ記事の更新に非常に時間がかかることがあった問題を修正
* 死んでいるホストをリストから削除した
    * 新規に有効にする分にはいいけど既に保存されているものについてはちょっと保留。。
    * 現在のタイムアウトは 2 秒にしているけど、体感ではもうちょっと長いように感じる

## 変更ファイル

* `plugin/qblog.inc.php`

## テスト方法

PHP 5.6 以上で確認すること。

1. QHMにログイン
2. 設定へ移動
3. ブログ設定へ移動
4. 外部連携タブへ移動
5. Ping送信「送信する」を選び、保存する
6. 「有効にしました」とメッセージが出るのを確認できれば **成功1**
7. 一度「設定」トップへ戻る
8. もう一度「ブログ設定」＞「外部連携」タブへ移動
9. Ping送信が「送信する」になっていれば **成功2**


## 死んだPing先リスト

以下を既に保存している場合、削除推奨。

```
http://api.my.yahoo.co.jp/RPC2
http://ping.rss.drecom.jp
http://rpc.reader.livedoor.com/ping
```

## タスク

- [ ] レビュー
- [ ] パッチバージョンアップ
