### PR TITLE
SSLサイトでのsocial_buttonsが機能しない不具合への対処

### DIFF
--- a/js/jquery.socialbutton-1.9.1.js
+++ b/js/jquery.socialbutton-1.9.1.js
@@ -496,7 +496,7 @@ function socialbutton_facebook_like(target, options, defaults, index, max_index)
 		'height': height
 	});
 
-	var tag = '<iframe src="http://www.facebook.com/plugins/like.php?' + params + '" scrolling="no" frameborder="0" style="border:none; overflow:hidden; width:' + width + 'px; height:' + height + 'px;" allowTransparency="true"></iframe>';
+	var tag = '<iframe src="//www.facebook.com/plugins/like.php?' + params + '" scrolling="no" frameborder="0" style="border:none; overflow:hidden; width:' + width + 'px; height:' + height + 'px;" allowTransparency="true"></iframe>';
 
 	$(target).html(tag);
 }
@@ -540,12 +540,12 @@ function socialbutton_twitter(target, options, defaults, index, max_index)
 		'data-related': related
 	});
 
-	var tag = '<a href="http://twitter.com/share" class="twitter-share-button"' + attr + '>Tweet</a>';
+	var tag = '<a href="//twitter.com/share" class="twitter-share-button"' + attr + '>Tweet</a>';
 
 	$(target).html(tag);
 
 	if (index == max_index) {
-		$('body').append('<script type="text/javascript" src="http://platform.twitter.com/widgets.js"></script>');
+		$('body').append('<script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>');
 	}
 }
 
@@ -753,7 +753,7 @@ function socialbutton_google_plusone(target, options, defaults, index, max_index
 		}
 
 		if (typeof gapi === 'undefined' || typeof gapi.plusone === 'undefined') {
-			$('body').append('<script type="text/javascript" src="https://apis.google.com/js/plusone.js">' + script_params + '</script>');
+			$('body').append('<script type="text/javascript" src="//apis.google.com/js/plusone.js">' + script_params + '</script>');
 		} else {
 			gapi.plusone.go();
 		}

--- a/lib/init.php
+++ b/lib/init.php
@@ -11,7 +11,7 @@
 // PukiWiki version / Copyright / Licence
 
 define('S_VERSION', '1.4.7');
-define('QHM_VERSION', '6.0.9');  //絶対に編集しないで下さい
+define('QHM_VERSION', '6.0.10');  //絶対に編集しないで下さい
 define('QHM_OPTIONS', 'update=download; support=false; banner=true');
 define('S_COPYRIGHT',
 	'powered by <strong><a href="http://www.open-qhm.net/">QHM</a> ' . QHM_VERSION . '</strong> haik<br />' .


### PR DESCRIPTION
Closes #16 

# 概要
* SSLサイトでsocial_buttonsを使うと、ボタンが表示されない不具合
* `js/jquery.socialbutton-1.9.1.js` 内の該当するボタンを取得する部分が、http通信になっていたので`http://`を削除して、SSLサイトでも動作するようにした

# TODO
- [x] レビュー
- [x] パッチバージョンアップ
- [ ] マージ