### PR TITLE
Imagick を利用するサーバーで画像のアップロードが正常にできるよう修正

### DIFF
--- a/lib/init.php
+++ b/lib/init.php
@@ -11,7 +11,7 @@
 // PukiWiki version / Copyright / Licence
 
 define('S_VERSION', '1.4.7');
-define('QHM_VERSION', '6.0.10');  //絶対に編集しないで下さい
+define('QHM_VERSION', '6.0.11');  //絶対に編集しないで下さい
 define('QHM_OPTIONS', 'update=download; support=false; banner=true');
 define('S_COPYRIGHT',
 	'powered by <strong><a href="http://www.open-qhm.net/">QHM</a> ' . QHM_VERSION . '</strong> haik<br />' .

--- a/plugin/skin_customizer/UploadHandler.php
+++ b/plugin/skin_customizer/UploadHandler.php
@@ -757,7 +757,13 @@ class UploadHandler
                     $image->setResourceLimit($type, $limit);
                 }
             }
-            $image->readImage($file_path);
+            try {
+                // QHM のインストールディレクトリのフルパスを取得する
+                $home_dir = dirname(dirname(__DIR__));
+                $image->readImage($home_dir . '/' . $file_path);
+            } catch (Exception $e) {
+                die($e->getMessage());
+            }
             $this->image_objects[$file_path] = $image;
         }
         return $this->image_objects[$file_path];
@@ -1090,7 +1096,7 @@ class UploadHandler
     protected function body($str) {
         echo $str;
     }
-    
+
     protected function header($str) {
         header($str);
     }
@@ -1299,6 +1305,7 @@ class UploadHandler
                 $content_range
             );
         }
+
         return $this->generate_response(
             array($this->options['param_name'] => $files),
             $print_response


### PR DESCRIPTION
## 概要

- 画像編集を Imagick を使って行うサーバーでテーマ編集から画像のアップロードができない問題に対応
- 主にロリポップサーバーが対象サーバーとなる
- Imagick を使わないサーバー（Xserver など）には影響が無い更新

## 原因と対処法について

`Imagick::readImage` に渡すパスが相対パスになっていると `unable to open image` という例外が発生し、処理が中断されてしまっていたようだ。
渡すパスを絶対パスにすることで正常に動作することを確認した。
以前は動いていたことから、 Imagick のバージョンによっては相対パスでもいけていたようだ。（未確認）
