### PR TITLE
[plugin]video をPHP7環境で動作させる #60

### DIFF
--- a/lib/init.php
+++ b/lib/init.php
@@ -11,7 +11,7 @@
 // PukiWiki version / Copyright / Licence
 
 define('S_VERSION', '1.4.7');
-define('QHM_VERSION', '7.0.0');  //絶対に編集しないで下さい
+define('QHM_VERSION', '7.0.1');  //絶対に編集しないで下さい
 define('QHM_OPTIONS', 'update=download; support=false; banner=true');
 define('S_COPYRIGHT',
 	'powered by <strong><a href="http://www.open-qhm.net/">HAIK</a> ' . QHM_VERSION . '</strong><br />' .

--- a/plugin/video.inc.php
+++ b/plugin/video.inc.php
@@ -240,7 +240,7 @@ EOD;
         $params['data-popup'] = 'popup';
     }
 
-    $attrs = '';
+    $attrs = array();
     foreach ($params as $key => $val)
     {
         if ($val === FALSE)


### PR DESCRIPTION
## このプルリクエストは何なのか？
connected to #60 

- PHP7.1で video プラグインが動作しない
- エラー発生箇所は文字列を格納した変数に対して配列操作を行っていた箇所（どうしてこうなった）
    ```
    Uncaught Error: [] operator not supported for strings  in /path/to/qhm/plugin/video.inc.php:252
    ```
- 普通に配列で初期化して動作確認した


## どうやってテストすればいいのか？

PHP7.1 で動作確認すること。

1. QHMにログインする
2. FrontPage を編集
2. どこかに `#video(hoge.mp4)` とページに書く（動画ファイルは無くてもOK）
3. 保存後、表示できればOK

## タスク

- [x] レビュー
- [x] バージョンアップ（パッチバージョン ⬆️ ）
- [ ] マージ