### PR TITLE
FontAwesome 4.7.0 へアップデート

### DIFF
--- a/lib/init.php
+++ b/lib/init.php
@@ -11,7 +11,7 @@
 // PukiWiki version / Copyright / Licence
 
 define('S_VERSION', '1.4.7');
-define('QHM_VERSION', '7.0.3');  //絶対に編集しないで下さい
+define('QHM_VERSION', '7.0.4');  //絶対に編集しないで下さい
 define('QHM_OPTIONS', 'update=download; support=false; banner=true');
 define('S_COPYRIGHT',
 	'powered by <strong><a href="http://www.open-qhm.net/">HAIK</a> ' . QHM_VERSION . '</strong><br />' .

--- a/lib/qhm_init_main.php
+++ b/lib/qhm_init_main.php
@@ -100,7 +100,7 @@ if ($is_bootstrap_skin)
     }
     $bootstrap_script = '<script type="text/javascript" src="skin/bootstrap/js/bootstrap.min.js"></script>';
     //FontAwesome
-    $bootstrap_script .= '<script src="https://use.fontawesome.com/f8a094c6b4.js"></script>';
+    $bootstrap_script .= '<script src="//maxcdn.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css"></script>';
     $qt->setv('bootstrap_script', $bootstrap_script);
 }
 

--- a/plugin/icon.inc.php
+++ b/plugin/icon.inc.php
@@ -50,7 +50,7 @@ function plugin_icon_inline()
 
 	$icon_name = $icon_prefix.$icon_name;
 
-	$format = '<i class="%s %s%s"></i>';
+	$format = '<i class="%s %s%s" aria-hidden="true"></i>';
 	return sprintf($format, h($icon_base), h($icon_name), $icon_options);
 }
 
@@ -58,7 +58,7 @@ function plugin_icon_set_font_awesome()
 {
     $qt = get_qt();
     $addcss = '
-<link href="//maxcdn.bootstrapcdn.com/font-awesome/4.3.0/css/font-awesome.min.css" rel="stylesheet">
+<link href="//maxcdn.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" rel="stylesheet">
 ';
     $qt->appendv_once('plugin_icon_font_awesome', 'beforescript', $addcss);
 }


### PR DESCRIPTION
## 概要

- FontAwesome のバージョンを `4.3.0` から `4.7.0` へアップデート
- 新しいアイコンが使えるよ

## タスク

- [x] マイナーバージョンアップ
- [ ] マージ
- [ ] タグ付け