### PR TITLE
設定画面の XSS-Protection を無効化

### DIFF
--- a/lib/init.php
+++ b/lib/init.php
@@ -11,7 +11,7 @@
 // PukiWiki version / Copyright / Licence
 
 define('S_VERSION', '1.4.7');
-define('QHM_VERSION', '7.0.4');  //絶対に編集しないで下さい
+define('QHM_VERSION', '7.0.5');  //絶対に編集しないで下さい
 define('QHM_OPTIONS', 'update=download; support=false; banner=true');
 define('S_COPYRIGHT',
 	'powered by <strong><a href="http://www.open-qhm.net/">HAIK</a> ' . QHM_VERSION . '</strong><br />' .

--- a/plugin/qhmsetting.inc.php
+++ b/plugin/qhmsetting.inc.php
@@ -15,6 +15,9 @@ function plugin_qhmsetting_action()
 	$qt = get_qt();
 	$qt->setv('no_menus', TRUE);//メニューやナビ等をconvertしない
 
+	// XSS-Protection を無効化
+	cancel_xss_protection();
+
 	$include_bs = '
 <link rel="stylesheet" href="skin/bootstrap/css/bootstrap.min.css" />
 <script type="text/javascript" src="skin/bootstrap/js/bootstrap.min.js"></script>';


### PR DESCRIPTION
Close #71 

## 概要

- Google Chrome （v56 以降）で発生
- 設定画面の「サイト情報」の入力欄に HTML 等を入力すると `ERR_BLOCKED_BY_XSS_AUDITOR` エラーが発生することがある
- 確認表示では全てのHTMLをエスケープして表示しているため具体的な発生条件が不明
- 設定画面では `X-XSS-Protection: 0` ヘッダーを投げることで回避

## テスト方法

1. ログイン
2. 設定＞サイト情報の設定
3. 「管理者ページ」に適当に script タグを入れる
    ```html
    <script>alert("XSS!");</script>
    ```
4. 確認画面に進む
5. エラーが表示されなければOK

## タスク

- [x] レビュー
- [x] パッチバージョンアップ
- [ ] マージ（リリース）
