### PR TITLE
[QBlog]ブログメニューのプレビューを改良

### DIFF
--- a/lib/init.php
+++ b/lib/init.php
@@ -11,7 +11,7 @@
 // PukiWiki version / Copyright / Licence
 
 define('S_VERSION', '1.4.7');
-define('QHM_VERSION', '7.0.5');  //絶対に編集しないで下さい
+define('QHM_VERSION', '7.0.6');  //絶対に編集しないで下さい
 define('QHM_OPTIONS', 'update=download; support=false; banner=true');
 define('S_COPYRIGHT',
 	'powered by <strong><a href="http://www.open-qhm.net/">HAIK</a> ' . QHM_VERSION . '</strong><br />' .

--- a/lib/qhm_init_main.php
+++ b/lib/qhm_init_main.php
@@ -215,7 +215,7 @@ if ( ! $qt->getv('no_menus'))
         global $menubar, $menubar2, $qblog_menubar;
         $vars['page_alt'] = $menubar;
 
-        if (is_qblog())
+        if (is_qblog() || $vars['page'] === $qblog_menubar)
         {
             do_plugin_convert('menu', $qblog_menubar);
         }

--- a/lib/qhm_init_main.php
+++ b/lib/qhm_init_main.php
@@ -223,6 +223,16 @@ if ( ! $qt->getv('no_menus'))
         $ptn = '"'.$script.'?'.rawurlencode($vars['page']).'"';
         $ptn = '|<(h[2-4][^>]+)>(.+href="('.$scripturi.')".+)?</(h[2-4])>|';
         $_menubody = preg_replace($ptn, '<$1 class="focus">$2</$4>', do_plugin_convert('menu'));
+
+        //プレビューならクラスを付ける
+        if ($vars['preview'] && $vars['page'] === $qblog_menubar )
+        {
+            if (trim($_menubody) !== '')
+            {
+                $_menubody = '<div class="preview_highlight">'. $_menubody .'</div>';
+            }
+        }
+
         if ($is_bootstrap_skin)
         {
             $_menubody = preg_replace('/<ul class="list1"\s*>/', '<ul class="list1 list-group">', $_menubody);

--- a/plugin/edit.inc.php
+++ b/plugin/edit.inc.php
@@ -207,10 +207,10 @@ $(function(){
 	$("body").append($div);
 
 	$div2.css({
-		width: 160,
+		width: 220,
 		height: 30,
 		position: "absolute",
-		left: $div.offset().left + $div.width() + 10 - 160,
+		left: $div.offset().left + $div.width() + 10 - 220,
 		top: $div.offset().top -22,
 		backgroundColor: "#FF6600",
 		color: "white",


### PR DESCRIPTION
Close #74 

## 概要

- QBlogメニューページのプレビューのみ、プレビューボックスが出ていなかった
- ていうかそもそもレンダリングしていなかった
- QBlog メニューのプレビューをその他ナビ等のプレビューと同様の挙動になるよう修正

## スクリーンショット
<img width="304" alt="2017-07-31 23 11 48" src="https://user-images.githubusercontent.com/808888/28781705-ebd45194-7645-11e7-9bda-a8f7e1636925.png">

## テスト方法

1. 管理者ログイン
2. ブログ＞メニュー編集
3. 適当に編集してプレビューボタン押す
4. プレビューが正常にできていたら成功

## タスク

- [x] レビュー
- [x] パッチバージョンアップ
- [ ] マージ
- [ ] タグ付け
- [ ] アップデートファイル生成
