### PR TITLE
ブログアーカイブを年ごとにまとめる

### DIFF
--- a/lib/init.php
+++ b/lib/init.php
@@ -11,7 +11,7 @@
 // PukiWiki version / Copyright / Licence
 
 define('S_VERSION', '1.4.7');
-define('QHM_VERSION', '7.0.6');  //絶対に編集しないで下さい
+define('QHM_VERSION', '7.1.0');  //絶対に編集しないで下さい
 define('QHM_OPTIONS', 'update=download; support=false; banner=true');
 define('S_COPYRIGHT',
 	'powered by <strong><a href="http://www.open-qhm.net/">HAIK</a> ' . QHM_VERSION . '</strong><br />' .

--- a/plugin/qblog/qblog.css
+++ b/plugin/qblog/qblog.css
@@ -297,3 +297,25 @@ display: block;
 .qblog_categories:after {
     clear: both;
 }
+
+.qblog_archives.by-year a:hover {
+  background-color: #f5f5f5;
+}
+
+.plugin-qblog-archives-year {
+  position: relative;
+}
+
+.plugin-qblog-archives-year::after {
+  display: block;
+  position: absolute;
+  font-family: 'Glyphicons Halflings';
+  content: "\e114";
+  right: 5px;
+  top: 5px;
+  color: #c0c0c0;
+}
+
+.plugin-qblog-archives-year.collapsed::after {
+  content: "\e080";
+}

--- a/plugin/qblog/qblog_archives.html
+++ b/plugin/qblog/qblog_archives.html
@@ -1,0 +1,7 @@
+<ul class="qblog_archives">
+  <?php foreach ($archives as $archive): ?>
+    <li>
+      <a href="<?php echo h($archive['url']) ?>"><?php echo h($archive['year']) ?>年<?php echo h($archive['month']) ?>月 (<?php echo h($archive['count']) ?>)</a>
+    </li>
+  <?php endforeach ?>
+</ul>

--- a/plugin/qblog/qblog_archives_by_year.html
+++ b/plugin/qblog/qblog_archives_by_year.html
@@ -1,0 +1,26 @@
+<div class="qblog_archives by-year">
+  <div class="list-group">
+    <?php foreach ($year_archives as $year_archive): ?>
+      <a
+        data-toggle="collapse"
+        href="#qblog_archives_by_year_<?php echo h($year_archive['year']) ?>"
+        class="list-group-item plugin-qblog-archives-year <?php echo $year_archive['collapse'] ? 'collapsed' : '' ?>"
+      >
+        <?php echo h($year_archive['year']) ?>年 (<?php echo h($year_archive['count']) ?>)
+      </a>
+      <div class="plugin-qblog-archives-year-container collapse <?php echo $year_archive['collapse'] ? '' : 'in' ?>" id="qblog_archives_by_year_<?php echo h($year_archive['year']) ?>">
+        <div class="list-group">
+          <?php foreach ($year_archive['archives'] as $archive): ?>
+            <a
+              href="<?php echo h($archive['url']) ?>"
+              class="list-group-item"
+              data-count="<?php echo h($archive['count']) ?>"
+            >
+              <?php echo h($archive['year']) ?>年<?php echo h($archive['month']) ?>月 (<?php echo h($archive['count']) ?>)
+            </a>
+          <?php endforeach ?>
+        </div>
+      </div>
+    <?php endforeach ?>
+  </div>
+</div>

--- a/plugin/qblog_archives.inc.php
+++ b/plugin/qblog_archives.inc.php
@@ -11,52 +11,122 @@
  *   modified :
  *
  *   Description
- *   
- *   
+ *
+ *
  *   Usage :
- *   
+ *
  */
 function plugin_qblog_archives_convert()
 {
-	global $vars, $script, $qblog_close;
+    global $vars, $script, $qblog_close;
 
-	//閉鎖中は何も表示しない
-	if ($qblog_close && ! ss_admin_check())
-	{
-		return '';
-	}
+    //閉鎖中は何も表示しない
+    if ($qblog_close && ! ss_admin_check())
+    {
+    return '';
+    }
 
+    $args = func_get_args();
 
-	//---- キャッシュのための処理を登録 -----
-	$qt = get_qt();
-	if($qt->create_cache) {
-	  $args = func_get_args();
-	  return $qt->get_dynamic_plugin_mark(__FUNCTION__, $args);
-	}
-	//------------------------------------
+    //---- キャッシュのための処理を登録 -----
+    $qt = get_qt();
+    if($qt->create_cache) {
+      return $qt->get_dynamic_plugin_mark(__FUNCTION__, $args);
+    }
+    //------------------------------------
 
-	$archives_file = CACHEQBLOG_DIR . 'qblog_archives.dat'; 
-	if( file_exists($archives_file) ){
-		$archives_list = file_get_contents($archives_file);
-	}
-	else{
-		$archives_list = array();
-	}
+    $by_year = false;        // 年数毎にまとめる
+    $by_year_threashold = 0; // 何件を超えたらまとめ出すか
 
-	$list = '';
-	$list .= '<ul class="qblog_archives">';
-	foreach (explode("\n", $archives_list) as $line)
-	{
-		if (rtrim($line) != '')
-		{
-			list($year, $month, $num) = explode(",", rtrim($line));
-			$archives_url = $script.'?QBlog&amp;mode=archives&amp;date='.rawurlencode($year.$month);
-			$list .= '<li><a href="'.$archives_url.'">'.$year.'年'.$month.'月 ('.$num.')'.'</a></li>';
-		}
-	}
-	$list .= '</ul>';
-	
-	return $list;
+    foreach ($args as $arg) {
+        $arg = trim($arg);
+        if (preg_match('/by_year(?:=(\d+))?/', $arg, $matches)) {
+            $by_year = true;
+            $by_year_threashold = (int)$matches[1];
+        }
+    }
+
+    $archives_file = CACHEQBLOG_DIR . 'qblog_archives.dat';
+    if( file_exists($archives_file) ){
+    $archives_list = file_get_contents($archives_file);
+    }
+    else{
+    $archives_list = array();
+    }
+
+    // 件数が by_year_threashold に満たなければ by_year を解除する
+    $archives = explode("\n", $archives_list);
+    if ($by_year && count($archives) < $by_year_threashold) {
+        $by_year = false;
+    }
+
+    $list = '';
+
+    if ($by_year) {
+        $current_year = 0;
+        $list .= '<div class="qblog_archives by-year">';
+        $list .= '<div class="">';
+        $year_heading = false;
+        foreach (explode("\n", $archives_list) as $line) {
+            if (rtrim($line) != '') {
+                list($year, $month, $num) = explode(",", rtrim($line));
+                if ($year != $current_year) {
+                    $current_year = $year;
+                    if ($year_heading) {
+                        $list .= '</div></div>';
+                    } else {
+                        $year_heading = true;
+                    }
+                    $list .= '<div class=""><a data-toggle="collapse" href="#qblog_archives_by_year_'.$year.'">'. $current_year .'</a></div><div class="plugin-qblog-archives-year-container collapse" id="qblog_archives_by_year_'.$year.'"><div class="">';
+                }
+                $archives_url = $script.'?QBlog&amp;mode=archives&amp;date='.rawurlencode($year.$month);
+                $list .= '<div class=""><a href="'.$archives_url.'">'.$year.'年'.$month.'月 ('.$num.')'.'</a></div>';
+            }
+        }
+        $list .= '</div></div></div></div>';
+    } else {
+        $list .= '<ul class="qblog_archives">';
+        foreach (explode("\n", $archives_list) as $line) {
+            if (rtrim($line) != '') {
+                list($year, $month, $num) = explode(",", rtrim($line));
+                $archives_url = $script.'?QBlog&amp;mode=archives&amp;date='.rawurlencode($year.$month);
+                $list .= '<li><a href="'.$archives_url.'">'.$year.'年'.$month.'月 ('.$num.')'.'</a></li>';
+            }
+        }
+        $list .= '</ul>';
+    }
+
+    if ($by_year) {
+        plugin_qblog_archives_set_js_for_by_year();
+    }
+
+    return $list;
 }
 
-?>
+function plugin_qblog_archives_set_js_for_by_year() {
+    $qt = get_qt();
+
+    $js = '
+<style>
+.plugin-qblog-archives-year-container {
+    overflow: hidden;
+}
+</style>
+<script>
+$(function(){
+    $(".plugin-qblog-archives-year").each(function(){
+        var year = $(this).data("year");
+        var $archives = $(".qblog_archives > li > a[data-year="+year+"]");
+        var $listItems = $archives.parent();
+        var count = $archives.length;
+        $(this).text(year + "年（" + count + "）");
+        var $subList = $(this).parent().after("<li><ul></ul></li>").next().find("ul");
+
+        $listItems.appendTo($subList);
+        $subList.collapse("hide");
+    });
+});
+</script>
+';
+    $qt->appendv_once('plugin_qblog_archives_set_js_for_by_year', 'beforescript', $js);
+}

--- a/plugin/qblog_archives.inc.php
+++ b/plugin/qblog_archives.inc.php
@@ -23,15 +23,15 @@ function plugin_qblog_archives_convert()
     //閉鎖中は何も表示しない
     if ($qblog_close && ! ss_admin_check())
     {
-    return '';
+        return '';
     }
 
     $args = func_get_args();
 
     //---- キャッシュのための処理を登録 -----
     $qt = get_qt();
-    if($qt->create_cache) {
-      return $qt->get_dynamic_plugin_mark(__FUNCTION__, $args);
+    if ($qt->create_cache) {
+        return $qt->get_dynamic_plugin_mark(__FUNCTION__, $args);
     }
     //------------------------------------
 
@@ -49,14 +49,14 @@ function plugin_qblog_archives_convert()
     }
 
     $archives_file = CACHEQBLOG_DIR . 'qblog_archives.dat';
-    if( file_exists($archives_file) ){
-    $archives_list = file_get_contents($archives_file);
+    if (file_exists($archives_file)) {
+        $archives_list = file_get_contents($archives_file);
     }
-    else{
-    $archives_list = array();
+    else {
+        $archives_list = array();
     }
 
-    $archives = array_map(function($line){
+    $archives = array_map(function($line) {
         list($year, $month, $num) = explode(",", rtrim($line));
         return array(
             'year' => $year,

--- a/plugin/qblog_archives.inc.php
+++ b/plugin/qblog_archives.inc.php
@@ -35,14 +35,15 @@ function plugin_qblog_archives_convert()
     }
     //------------------------------------
 
-    $by_year = false;        // 年数毎にまとめる
-    $by_year_threashold = 0; // 何件を超えたらまとめ出すか
+    $by_year = false; // 年数毎にまとめる
+    $default_year_collapse = false;
 
     foreach ($args as $arg) {
         $arg = trim($arg);
-        if (preg_match('/by_year(?:=(\d+))?/', $arg, $matches)) {
+        if ($arg === 'by_year') {
             $by_year = true;
-            $by_year_threashold = (int)$matches[1];
+        } else if ($arg === 'year_collapse') {
+            $default_year_collapse = true;
         }
     }
 
@@ -56,9 +57,6 @@ function plugin_qblog_archives_convert()
 
     // 件数が by_year_threashold に満たなければ by_year を解除する
     $archives = explode("\n", $archives_list);
-    if ($by_year && count($archives) < $by_year_threashold) {
-        $by_year = false;
-    }
 
     $list = '';
 
@@ -78,7 +76,7 @@ function plugin_qblog_archives_convert()
                     } else {
                         $year_heading = true;
                     }
-                    $year_collapse = $current_year !== date('Y');
+                    $year_collapse = $default_year_collapse ? true : ($current_year !== date('Y'));
                     $list .= '<a data-toggle="collapse" href="#qblog_archives_by_year_'.$year.'" class="list-group-item plugin-qblog-archives-year '. ($year_collapse ? 'collapsed' : '') .'">'. $current_year .'</a><div class="plugin-qblog-archives-year-container collapse '. ($year_collapse ? '' : 'in') .'" id="qblog_archives_by_year_'.$year.'"><div class="list-group">';
                 }
                 $archives_url = $script.'?QBlog&amp;mode=archives&amp;date='.rawurlencode($year.$month);

--- a/plugin/qblog_archives.inc.php
+++ b/plugin/qblog_archives.inc.php
@@ -65,8 +65,9 @@ function plugin_qblog_archives_convert()
     if ($by_year) {
         $current_year = 0;
         $list .= '<div class="qblog_archives by-year">';
-        $list .= '<div class="">';
+        $list .= '<div class="list-group">';
         $year_heading = false;
+        $year_collapse = true;
         foreach (explode("\n", $archives_list) as $line) {
             if (rtrim($line) != '') {
                 list($year, $month, $num) = explode(",", rtrim($line));
@@ -77,10 +78,11 @@ function plugin_qblog_archives_convert()
                     } else {
                         $year_heading = true;
                     }
-                    $list .= '<div class=""><a data-toggle="collapse" href="#qblog_archives_by_year_'.$year.'">'. $current_year .'</a></div><div class="plugin-qblog-archives-year-container collapse" id="qblog_archives_by_year_'.$year.'"><div class="">';
+                    $year_collapse = $current_year !== date('Y');
+                    $list .= '<a data-toggle="collapse" href="#qblog_archives_by_year_'.$year.'" class="list-group-item plugin-qblog-archives-year '. ($year_collapse ? 'collapsed' : '') .'">'. $current_year .'</a><div class="plugin-qblog-archives-year-container collapse '. ($year_collapse ? '' : 'in') .'" id="qblog_archives_by_year_'.$year.'"><div class="list-group">';
                 }
                 $archives_url = $script.'?QBlog&amp;mode=archives&amp;date='.rawurlencode($year.$month);
-                $list .= '<div class=""><a href="'.$archives_url.'">'.$year.'年'.$month.'月 ('.$num.')'.'</a></div>';
+                $list .= '<a href="'.$archives_url.'" class="list-group-item" data-count="'. $num .'">'.$year.'年'.$month.'月 ('.$num.')'.'</a>';
             }
         }
         $list .= '</div></div></div></div>';
@@ -107,23 +109,16 @@ function plugin_qblog_archives_set_js_for_by_year() {
     $qt = get_qt();
 
     $js = '
-<style>
-.plugin-qblog-archives-year-container {
-    overflow: hidden;
-}
-</style>
 <script>
 $(function(){
     $(".plugin-qblog-archives-year").each(function(){
-        var year = $(this).data("year");
-        var $archives = $(".qblog_archives > li > a[data-year="+year+"]");
-        var $listItems = $archives.parent();
-        var count = $archives.length;
+        var year = $(this).text();
+        var $archives = $(this).next().find("a");
+        var count = 0;
+        $archives.each(function(){
+            count += parseInt($(this).data("count"), 10);
+        });
         $(this).text(year + "年（" + count + "）");
-        var $subList = $(this).parent().after("<li><ul></ul></li>").next().find("ul");
-
-        $listItems.appendTo($subList);
-        $subList.collapse("hide");
     });
 });
 </script>


### PR DESCRIPTION
## 概要

- `#qblog_archives` の改良
- ブログアーカイブを年ごとにまとめて表示できる `by_year` オプションを追加

[GIF動画](https://gyazo.com/7160a419edaa45a694dfcca7af561dea)

## 使い方

```
// 年ごとに表示（今年分は開いておく）
#qblog_archives(by_year)

// 年ごとに表示（今年分も閉じておく）
#qblog_archives(by_year,year_collapse)

// 通常表示
#qblog_archives
```

## タスク

- [x] レビュー
- [x] マイナーバージョンアップ
- [ ] マージ
- [ ] タグ付け
- [ ] アップデートファイル生成
