### PR TITLE
ブログアーカイブの月別リンクの表示を改良

### DIFF
--- a/lib/init.php
+++ b/lib/init.php
@@ -11,7 +11,7 @@
 // PukiWiki version / Copyright / Licence
 
 define('S_VERSION', '1.4.7');
-define('QHM_VERSION', '7.1.0');  //絶対に編集しないで下さい
+define('QHM_VERSION', '7.1.1');  //絶対に編集しないで下さい
 define('QHM_OPTIONS', 'update=download; support=false; banner=true');
 define('S_COPYRIGHT',
 	'powered by <strong><a href="http://www.open-qhm.net/">HAIK</a> ' . QHM_VERSION . '</strong><br />' .

--- a/plugin/qblog/qblog.css
+++ b/plugin/qblog/qblog.css
@@ -319,3 +319,7 @@ display: block;
 .plugin-qblog-archives-year.collapsed::after {
   content: "\e080";
 }
+
+.plugin-qblog-archives-unvisible-year {
+  visibility: hidden;
+}

--- a/plugin/qblog/qblog_archives_by_year.html
+++ b/plugin/qblog/qblog_archives_by_year.html
@@ -16,7 +16,7 @@
               class="list-group-item"
               data-count="<?php echo h($archive['count']) ?>"
             >
-              <?php echo h($archive['year']) ?>年<?php echo h($archive['month']) ?>月 (<?php echo h($archive['count']) ?>)
+              <span class="plugin-qblog-archives-unvisible-year"><?php echo h($archive['year']) ?>年</span><?php echo h($archive['month']) ?>月 (<?php echo h($archive['count']) ?>)
             </a>
           <?php endforeach ?>
         </div>


### PR DESCRIPTION
## 概要

- ブログアーカイブを年別表示 `by_year` にすると、月別リンクの表示が冗長だった
- 年数を非表示にして対応

## スクリーンショット
<img width="245" alt="2017-08-28 20 24 59" src="https://user-images.githubusercontent.com/808888/29771846-cdf2b76e-8c30-11e7-9c66-b185cd584cef.png">

## タスク

- [x] レビュー
- [x] パッチバージョンアップ
- [ ] リリース
- [ ] タグ付け
- [ ] 更新ファイル生成
