### PR TITLE
モバイルプレビュー時にスクロールできない問題を修正

### DIFF
--- a/js/jquery.edit.js
+++ b/js/jquery.edit.js
@@ -19,7 +19,7 @@ $(document).ready(function(){
 		var $links = $("#mobilesm, #mobilemd, #mobilelg, #tablet, #laptop, #desktop");
 
 		$links.on("click", function(){
-			var features = "menubar=no,location=no,resizable=yes,status=no,toolbar=no,";
+			var features = "menubar=no,location=no,resizable=yes,status=no,toolbar=no,scrollbars=yes,";
 			switch ($(this).attr("id")) {
 				case "mobilesm":
 					features += "width=320,height=568,top=50,left=500";

--- a/lib/init.php
+++ b/lib/init.php
@@ -11,7 +11,7 @@
 // PukiWiki version / Copyright / Licence
 
 define('S_VERSION', '1.4.7');
-define('QHM_VERSION', '7.1.1');  //絶対に編集しないで下さい
+define('QHM_VERSION', '7.1.2');  //絶対に編集しないで下さい
 define('QHM_OPTIONS', 'update=download; support=false; banner=true');
 define('S_COPYRIGHT',
 	'powered by <strong><a href="http://www.open-qhm.net/">HAIK</a> ' . QHM_VERSION . '</strong><br />' .


### PR DESCRIPTION
#79 

## 概要

- Firefox で発生していた問題
- menubar=no あるいは toolbar=no を指定した際に scrollbars=yes を明示しないとスクロール不能となる
- Firefox, Chrome, Safari で動作確認済み

## スクリーンショット

スクロールでき、ページ半ばのコンテンツが表示できる。
<img width="335" alt="2017-12-20 0 25 34" src="https://user-images.githubusercontent.com/808888/34164222-5236035c-e51c-11e7-8c51-dc8cd607c9c2.png">

## タスク

- [x] レビュー
- [x] パッチバージョンアップ `v7.1.2`
- [ ] マージ
- [ ] タグ付け＆リリース作成
- [ ] 更新ファイル生成