### PR TITLE
HAIKでも差分を色分けする

### DIFF
--- a/plugin/diff.inc.php
+++ b/plugin/diff.inc.php
@@ -14,11 +14,11 @@ function plugin_diff_action()
 	global $layout_pages, $style_name;
 
 	$editable = edit_auth($page, FALSE, FALSE);
-    if(!$editable){
-        header("Location: $script");
-        exit();        
-    }
-    
+	if(!$editable){
+		header("Location: $script");
+		exit();
+	}
+
 	$page = isset($vars['page']) ? $vars['page'] : '';
 	check_readable($page, true, true);
 
@@ -29,6 +29,9 @@ function plugin_diff_action()
 		$style_name = '..';
 		$is_layout = TRUE;
 	}
+
+	// スタイルシートを出力
+	plugin_diff_set_css();
 
 	$action = isset($vars['action']) ? $vars['action'] : '';
 	switch ($action) {
@@ -43,7 +46,7 @@ function plugin_diff_view($page)
 	global $script, $hr;
 	global $layout_pages;
 	$qm = get_qm();
-	
+
 	$r_page = rawurlencode($page);
 	$s_page = htmlspecialchars($page);
 
@@ -106,7 +109,7 @@ function plugin_diff_delete($page)
 {
 	global $script, $vars;
 	$qm = get_qm();
-	
+
 	$filename = DIFF_DIR . encode($page) . '.txt';
 	$body = '';
 	if (! is_pagename($page))     $body = 'Invalid page name';
@@ -141,4 +144,19 @@ EOD;
 
 	return array('msg'=>$qm->m['plg_diff']['title_delete'], 'body'=>$body);
 }
-?>
+
+function plugin_diff_set_css() {
+	$qt = get_qt();
+	$style_tag = <<< HTML
+<style>
+span.diff_added {
+  color: blue;
+}
+
+span.diff_removed {
+  color: red;
+}
+</style>
+HTML;
+	$qt->appendv_once('plugin_diff_css', 'beforescript', $style_tag);
+}


### PR DESCRIPTION
## 概要
Ref #82 
- QHMで利用していたCSS指定が無くなっていたため色分けされなくなっていた
- `diff` プラグインがCSSを出力するようにして対応

## テスト方法
- 適当なページを編集する（行の追加、削除を行う）
- 「このページの」＞「差分」を表示
- 色分けされていたら成功

## スクリーンショット
**before**
<img width="360" alt="2018-01-09 22 54 33" src="https://user-images.githubusercontent.com/808888/34724120-183a299c-f590-11e7-877c-d349b23d4b23.png">

**after**
<img width="439" alt="2018-01-09 22 53 55" src="https://user-images.githubusercontent.com/808888/34724097-06e28fa4-f590-11e7-814e-840bb3d2a3dc.png">
