### PR TITLE
キャッシュ設定画面にプラグインキャッシュの削除機能を追加

### DIFF
--- a/lib/init.php
+++ b/lib/init.php
@@ -11,7 +11,7 @@
 // PukiWiki version / Copyright / Licence
 
 define('S_VERSION', '1.4.7');
-define('QHM_VERSION', '7.1.3');  //絶対に編集しないで下さい
+define('QHM_VERSION', '7.1.4');  //絶対に編集しないで下さい
 define('QHM_OPTIONS', 'update=download; support=false; banner=true');
 define('S_COPYRIGHT',
 	'powered by <strong><a href="http://www.open-qhm.net/">HAIK</a> ' . QHM_VERSION . '</strong><br />' .

--- a/plugin/qhmsetting.inc.php
+++ b/plugin/qhmsetting.inc.php
@@ -3301,8 +3301,8 @@ EOD;
 
 	if (count($plugin_caches) > 0) {
 		$body .= <<< HTML
-<h3 style="margin-top:2em;">その他プラグイン用キャッシュの初期化</h3>
-<p>その他プラグインにより生成されたキャッシュを削除します。<br />
+<h3 style="margin-top:2em;">プラグイン用キャッシュの初期化</h3>
+<p>プラグインにより生成されたキャッシュを削除します。<br />
 下記プラグインの挙動が改善する可能性があります。</p>
 <ul>
 	<li><code>contentsx</code></li>

--- a/plugin/qhmsetting.inc.php
+++ b/plugin/qhmsetting.inc.php
@@ -3296,6 +3296,38 @@ EOD;
 EOD;
     }
 
+	// プラグインのキャッシュファイル
+	$plugin_caches = plugin_qhmsetting_get_plugin_cache_files();
+
+	if (count($plugin_caches) > 0) {
+		$body .= <<< HTML
+<h3 style="margin-top:2em;">その他プラグイン用キャッシュの初期化</h3>
+<p>その他プラグインにより生成されたキャッシュを削除します。<br />
+下記プラグインの挙動が改善する可能性があります。</p>
+<ul>
+	<li><code>contentsx</code></li>
+</ul>
+<p>削除ファイルを確認し、よろしければ「削除を実行する」ボタンを押してください。</p>
+<form action="{$script}" method="post">
+	<ul>
+HTML;
+		foreach ($plugin_caches as $file) {
+			$body .= <<< HTML
+		<li class="qhm-plugin-cache-file">{$file}</li>
+HTML;
+		}
+
+		$body .= <<< HTML
+	</ul>
+
+	<input type="hidden" name="plugin_del" value="plugin_del" />
+	<input type="hidden" name="phase" value="clear" />
+	<input type="hidden" name="mode" value="msg" />
+	<input type="hidden" name="cmd" value="qhmsetting" />
+	<p><input type="submit" name="clear" value="削除を実行する" class="btn btn-primary"></p>
+</form>
+HTML;
+	}
 
 	return $body;
 }
@@ -3453,6 +3485,36 @@ EOD;
 </ul>
 ';
 	}
+
+	// ----------------- プラグインキャッシュの削除 ----------------
+	if (isset($vars['plugin_del'])) {
+		$files = plugin_qhmsetting_get_plugin_cache_files();
+		$oks = array();
+		foreach ($files as $i => $file) {
+			if (unlink($file)) {
+				$oks[] = $file;
+			}
+		}
+		$_SESSION['flash_msg'] = <<< HTML
+<h2>プラグインキャッシュの削除完了</h2>
+<p>以下のファイルを削除しました。</p>
+<ul>
+HTML;
+		foreach ($oks as $file) {
+			$_SESSION['flash_msg'] .= <<< HTML
+	<li>{$file}</li>
+HTML;
+		}
+
+		$_SESSION['flash_msg'] .= <<< HTML
+</ul>
+HTML;
+	}
+}
+
+function plugin_qhmsetting_get_plugin_cache_files() {
+	$plugin_caches = glob(CACHE_DIR . '*.contentsx');
+	return $plugin_caches;
 }
 
 function plugin_qhmsetting_clear_view_search2_cache()


### PR DESCRIPTION
## 概要

Close #81 
- `#contentsx` のキャッシュを一括削除する機能が無いので設定画面に追加した
- 他のプラグインがキャッシュファイルを使う可能性もあるのでプラグインキャッシュとしてまとめた

## テスト方法

※v7.1.3 にアップデートしたが、表示が回復しないページがある場合は「v7.1.3 にアップデートしたものの、表示が回復しないページがある場合」のテストを行う。

1. 適当なページで `#contentsx` を設置する
2. 設定＞高速化設定、キャッシュの初期化へ移動
3. 「プラグイン用キャッシュの初期化」セクションを見る
4. 設置したページの数だけリストがあればOK
5. 「削除を実行する」をクリック
6. 削除が成功したメッセージが表示されれば成功

### v7.1.3 にアップデートしたものの、表示が回復しないページがある場合

1. 設定＞高速化設定、キャッシュの初期化へ移動
2. 「プラグイン用キャッシュの初期化」セクションを見る
3. 「削除を実行する」をクリック
4. 削除が成功したメッセージが表示される
5. 問題のページの表示を確認する

## スクリーンショット

**設定画面**
<img width="636" alt="2018-01-10 22 42 08" src="https://user-images.githubusercontent.com/808888/34775722-7fa9388a-f657-11e7-9348-1230aa1662c2.png">

**完了画面**
<img width="594" alt="2018-01-10 22 25 10" src="https://user-images.githubusercontent.com/808888/34775729-8698978a-f657-11e7-9827-241cd59ba607.png">

## タスク

- [x] レビュー
- [x] パッチバージョン更新
- [ ] マージ
- [ ] タグ付け
- [ ] 更新ファイル生成