### PR TITLE
Add support of apahce 2.4's access control syntax in .htaccess files

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -2,13 +2,23 @@
 
 # Prohibit direct access
 <FilesMatch "\.(ini\.php|lng\.php|txt|gz|tgz)$">
-	Order allow,deny
-	Deny from all
+	<IfVersion >= 2.4>
+		Require all denied
+	</IfVersion>
+	<IfVersion < 2.4>
+		Order allow,deny
+		Deny from all
+	</IfVersion>
 </FilesMatch>
 
 <FilesMatch "^robots.txt$">
-	Order allow,deny
-	Allow from all
+	<IfVersion >= 2.4>
+		Require all granted
+	</IfVersion>
+	<IfVersion < 2.4>
+		Order allow,deny
+		Allow from all
+	</IfVersion>
 </FilesMatch>
 
 ## Add Content-Type for web-fonts and videos

--- a/attach/.htaccess
+++ b/attach/.htaccess
@@ -1,2 +1,7 @@
-Order allow,deny
-Deny from all
+<IfVersion >= 2.4>
+	Require all denied
+</IfVersion>
+<IfVersion < 2.4>
+	Order allow,deny
+	Deny from all
+</IfVersion>

--- a/backup/.htaccess
+++ b/backup/.htaccess
@@ -1,2 +1,7 @@
-Order allow,deny
-Deny from all
+<IfVersion >= 2.4>
+	Require all denied
+</IfVersion>
+<IfVersion < 2.4>
+	Order allow,deny
+	Deny from all
+</IfVersion>

--- a/cache/.htaccess
+++ b/cache/.htaccess
@@ -1,7 +1,17 @@
-Order allow,deny
-Deny from all
+<IfVersion >= 2.4>
+	Require all denied
+</IfVersion>
+<IfVersion < 2.4>
+	Order allow,deny
+	Deny from all
+</IfVersion>
 
 # Amazon plugin's Image cache
 <FilesMatch ".*\.(jpg|JPG|png|PNG|gif|GIF|jpeg|JPEG)$">
-	Allow from all
+	<IfVersion >= 2.4>
+		Require all granted
+	</IfVersion>
+	<IfVersion < 2.4>
+		Allow from all
+	</IfVersion>
 </FilesMatch>

--- a/counter/.htaccess
+++ b/counter/.htaccess
@@ -1,2 +1,7 @@
-Order allow,deny
-Deny from all
+<IfVersion >= 2.4>
+	Require all denied
+</IfVersion>
+<IfVersion < 2.4>
+	Order allow,deny
+	Deny from all
+</IfVersion>

--- a/diff/.htaccess
+++ b/diff/.htaccess
@@ -1,2 +1,7 @@
-Order allow,deny
-Deny from all
+<IfVersion >= 2.4>
+	Require all denied
+</IfVersion>
+<IfVersion < 2.4>
+	Order allow,deny
+	Deny from all
+</IfVersion>

--- a/plugin/greybox/.htaccess
+++ b/plugin/greybox/.htaccess
@@ -1,2 +1,7 @@
-Order allow,deny
-allow from all
+<IfVersion >= 2.4>
+	Require all granted
+</IfVersion>
+<IfVersion < 2.4>
+	Order allow,deny
+	Allow from all
+</IfVersion>

--- a/plugin/lightbox2/.htaccess
+++ b/plugin/lightbox2/.htaccess
@@ -1,2 +1,7 @@
-Order allow,deny
-allow from all
+<IfVersion >= 2.4>
+	Require all granted
+</IfVersion>
+<IfVersion < 2.4>
+	Order allow,deny
+	Allow from all
+</IfVersion>

--- a/plugin/playlist/.htaccess
+++ b/plugin/playlist/.htaccess
@@ -1,2 +1,7 @@
-Order allow,deny
-allow from all
+<IfVersion >= 2.4>
+	Require all granted
+</IfVersion>
+<IfVersion < 2.4>
+	Order allow,deny
+	Allow from all
+</IfVersion>

--- a/swfu/.htaccess
+++ b/swfu/.htaccess
@@ -1,5 +1,10 @@
 # Prohibit direct access
 <FilesMatch "\.(ini\.php|lng\.php|txt|gz|tgz)$">
-	Order allow,deny
-	Allow from all
+	<IfVersion >= 2.4>
+		Require all granted
+	</IfVersion>
+	<IfVersion < 2.4>
+		Order allow,deny
+		Allow from all
+	</IfVersion>
 </FilesMatch>

--- a/swfu/d/.htaccess
+++ b/swfu/d/.htaccess
@@ -1,4 +1,9 @@
 # Prohibit direct access
 <FilesMatch "\.(php[3457]?|pht|phtml|cgi|pl|exe|com)$">
-    Deny from all
+	<IfVersion >= 2.4>
+		Require all denied
+	</IfVersion>
+	<IfVersion < 2.4>
+		Deny from all
+	</IfVersion>
 </FilesMatch>

--- a/trackback/.htaccess
+++ b/trackback/.htaccess
@@ -1,2 +1,7 @@
-Order allow,deny
-Deny from all
+<IfVersion >= 2.4>
+	Require all denied
+</IfVersion>
+<IfVersion < 2.4>
+	Order allow,deny
+	Deny from all
+</IfVersion>

--- a/wiki/.htaccess
+++ b/wiki/.htaccess
@@ -1,2 +1,7 @@
-Order allow,deny
-Deny from all
+<IfVersion >= 2.4>
+	Require all denied
+</IfVersion>
+<IfVersion < 2.4>
+	Order allow,deny
+	Deny from all
+</IfVersion>


### PR DESCRIPTION
apache 2.4 以降では、アクセスコントロールの書き方に変更が加わりました。apache 2.4 以降でも動作させるためのパッチを書きましたので、マージのご検討をいただければ幸いです。