### PR TITLE
[QBlog]リスト表示のサムネイル画像の歪みを修正

### DIFF
--- a/lib/func.php
+++ b/lib/func.php
@@ -2033,3 +2033,17 @@ function get_qhm_option($key = NULL)
 function cancel_xss_protection() {
     header('X-XSS-Protection: 0');
 }
+
+/**
+ * 生の JavaScript を <script></script> で囲む。
+ *
+ * @param [String] $js JavaScript
+ * @param [String] $delimiter タグの前後に入れる区切り文字。デフォルトで改行
+ */
+function wrap_script_tag($js, $delimiter = "\n") {
+	$lines = array();
+	$lines[] = '<script>';
+	$lines[] = $js;
+	$lines[] = '</script>';
+	return join($delimiter, $lines) . $delimiter;
+}

--- a/lib/init.php
+++ b/lib/init.php
@@ -11,7 +11,7 @@
 // PukiWiki version / Copyright / Licence
 
 define('S_VERSION', '1.4.7');
-define('QHM_VERSION', '7.1.5');  //絶対に編集しないで下さい
+define('QHM_VERSION', '7.1.6');  //絶対に編集しないで下さい
 define('QHM_OPTIONS', 'update=download; support=false; banner=true');
 define('S_COPYRIGHT',
 	'powered by <strong><a href="http://www.open-qhm.net/">HAIK</a> ' . QHM_VERSION . '</strong><br />' .

--- a/plugin/qblog/fix_distortion_of_thumbnails.js
+++ b/plugin/qblog/fix_distortion_of_thumbnails.js
@@ -1,0 +1,19 @@
+/**
+ * QBlog の古いリストテンプレートの構造を最新のものに変換する。
+ */
+$(function(){
+  $(".qblog-list-table .qblog_thumbnail").each(function(){
+    var $img  = $(this);
+    var $a    = $(this).closest("a");
+    var $date = $a.find('.qblog_date');
+
+    var thumbnailUrl = $img.attr("src");
+
+    var $box = $('<div></div>').addClass("qblog_thumbnail_box").css({backgroundImage: "url('" + thumbnailUrl + "')"});
+    var $newDate = $('<div></div>').addClass("qblog_date").text($date.text());
+    $box.append($newDate);
+    $a.append($box);
+    $img.remove();
+    $date.remove();
+  });
+});

--- a/plugin/qblog/list_template.html
+++ b/plugin/qblog/list_template.html
@@ -3,13 +3,13 @@
  *   Template for QBlog List
  *   -------------------------------------------
  *   ./plugin/qblog/list_template.html
- *   
+ *
  *   Copyright (c) 2012 hokuken
  *   http://hokuken.com/
- *   
+ *
  *   created  : 12/07/30
  *   modified :
- *   
+ *
  */
 ?>
 
@@ -17,8 +17,11 @@
 <ul>
 <?php foreach ($posts as $post):?>
 	<li>
-		<a href="<?php echo h($post['url'])?>"><img src="<?php echo h($post['image'])?>" class="qblog_thumbnail"/>
-		<span class="qblog_date"><?php echo h($post['date'])?></span></a>
+		<a href="<?php echo h($post['url'])?>">
+			<div class="qblog_thumbnail_box" style="background-image: url(<?php echo h($post['image'])?>)">
+				<div class="qblog_date"><?php echo h($post['date'])?></div>
+			</div>
+		</a>
 		<h2 class="qblog_title no-toc"><a href="<?php echo h($post['url'])?>"><?php echo h($post['title'])?></a></h2>
 		<p class="qblog_abstract"><a href="<?php echo h($post['url'])?>"><?php echo h($post['abstract'])?></a></p>
 	</li>

--- a/plugin/qblog/qblog.css
+++ b/plugin/qblog/qblog.css
@@ -101,6 +101,14 @@ float: left;
 margin-right: 16px;
 display: block;
 }
+.qblog-list-table .qblog_thumbnail_box {
+width: 120px;
+height: 120px;
+background-size: cover;
+background-position: center;
+float: left;
+margin-right: 16px;
+}
 .qblog_date {
 position: absolute;
 top:100px;

--- a/skin/hokukenstyle/haik_seed/qblog_list_template.html
+++ b/skin/hokukenstyle/haik_seed/qblog_list_template.html
@@ -3,13 +3,13 @@
  *   Template for QBlog List
  *   -------------------------------------------
  *   qblog_list_template.html
- *   
+ *
  *   Copyright (c) 2015 hokuken
  *   http://hokuken.com/
- *   
+ *
  *   created  : 15/06/26
  *   modified :
- *   
+ *
  */
 ?>
 <div id="qblog_list" class="qblog-list qblog-list-<?php echo h($list_type)?>">
@@ -28,22 +28,25 @@
     </div>
   <?php endforeach;?>
   </div>
-  
+
   <?php else : ?>
 
   <ul>
   <?php foreach ($posts as $post):?>
-  	<li>
-  		<a href="<?php echo h($post['url'])?>"><img src="<?php echo h($post['image'])?>" class="qblog_thumbnail">
-  		<span class="qblog_date"><?php echo h($post['date'])?></span></a>
-  		<h2 class="qblog_title no-toc"><a href="<?php echo h($post['url'])?>"><?php echo h($post['title'])?></a></h2>
-  		<p class="qblog_abstract"><a href="<?php echo h($post['url'])?>"><?php echo h($post['abstract'])?></a></p>
-  	</li>
+    <li>
+      <a href="<?php echo h($post['url'])?>">
+        <div class="qblog_thumbnail_box" style="background-image: url(<?php echo h($post['image'])?>)">
+          <div class="qblog_date"><?php echo h($post['date'])?></div>
+        </div>
+      </a>
+      <h2 class="qblog_title no-toc"><a href="<?php echo h($post['url'])?>"><?php echo h($post['title'])?></a></h2>
+      <p class="qblog_abstract"><a href="<?php echo h($post['url'])?>"><?php echo h($post['abstract'])?></a></p>
+    </li>
   <?php endforeach;?>
   </ul>
-  
+
   <?php endif; ?>
-  
+
   <?php if ($list_type == 'table'):?>
   <ul class="pagination">
   <?php foreach ($paginates as $label => $url):?>


### PR DESCRIPTION
Close #87 

## 概要
- ブログ記事のサムネイル画像の縦横比によっては歪んでしまう問題を修正
    - 画像の中央付近が正方形に最大限納まるように表示される
    - 横長であれば左右がカットされ、縦長であれば上下がカットされる（スクショ参照）
- 下記テーマについて QBlogリストテンプレートを修正することで対応
    - 非 haik テーマ（デフォルトQBlogリストテンプレート）
    - haik_seed テーマ
- 上記以外の配布済みの haik テーマについてはこのレポジトリに含まないため修正ができないが、動的に修正する JavaScript を同梱したのでそれにより自動的に修正される

## テスト方法

- 各haikテーマのQBlogリスト表示のサムネイル画像が正常に表示されていればOK


## スクリーンショット

**before**
<img width="450" alt="2018-02-02 13 58 04" src="https://user-images.githubusercontent.com/808888/35717396-64fedd5a-0822-11e8-9c81-6d61c6f39141.png">

**after**
<img width="441" alt="2018-02-02 13 58 56" src="https://user-images.githubusercontent.com/808888/35717401-6994535e-0822-11e8-87ea-0c8a29b825e0.png">

## タスク

- [x] レビュー
- [x] パッチバージョンアップ
- [ ] マージ（リリース）
- [ ] 更新ファイル生成
