### PR TITLE
Fix apache access control configuration

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -2,23 +2,23 @@
 
 # Prohibit direct access
 <FilesMatch "\.(ini\.php|lng\.php|txt|gz|tgz)$">
-	<IfVersion >= 2.4>
+	<IfModule authz_host_module>
 		Require all denied
-	</IfVersion>
-	<IfVersion < 2.4>
+	</IfModule>
+	<IfModule !authz_host_module>
 		Order allow,deny
 		Deny from all
-	</IfVersion>
+	</IfModule>
 </FilesMatch>
 
 <FilesMatch "^robots.txt$">
-	<IfVersion >= 2.4>
+	<IfModule authz_host_module>
 		Require all granted
-	</IfVersion>
-	<IfVersion < 2.4>
+	</IfModule>
+	<IfModule !authz_host_module>
 		Order allow,deny
 		Allow from all
-	</IfVersion>
+	</IfModule>
 </FilesMatch>
 
 ## Add Content-Type for web-fonts and videos

--- a/attach/.htaccess
+++ b/attach/.htaccess
@@ -1,7 +1,7 @@
-<IfVersion >= 2.4>
+<IfModule authz_host_module>
 	Require all denied
-</IfVersion>
-<IfVersion < 2.4>
+</IfModule>
+<IfModule !authz_host_module>
 	Order allow,deny
 	Deny from all
-</IfVersion>
+</IfModule>

--- a/backup/.htaccess
+++ b/backup/.htaccess
@@ -1,7 +1,7 @@
-<IfVersion >= 2.4>
+<IfModule authz_host_module>
 	Require all denied
-</IfVersion>
-<IfVersion < 2.4>
+</IfModule>
+<IfModule !authz_host_module>
 	Order allow,deny
 	Deny from all
-</IfVersion>
+</IfModule>

--- a/cache/.htaccess
+++ b/cache/.htaccess
@@ -1,17 +1,17 @@
-<IfVersion >= 2.4>
+<IfModule authz_host_module>
 	Require all denied
-</IfVersion>
-<IfVersion < 2.4>
+</IfModule>
+<IfModule !authz_host_module>
 	Order allow,deny
 	Deny from all
-</IfVersion>
+</IfModule>
 
 # Amazon plugin's Image cache
 <FilesMatch ".*\.(jpg|JPG|png|PNG|gif|GIF|jpeg|JPEG)$">
-	<IfVersion >= 2.4>
+	<IfModule authz_host_module>
 		Require all granted
-	</IfVersion>
-	<IfVersion < 2.4>
+	</IfModule>
+	<IfModule !authz_host_module>
 		Allow from all
-	</IfVersion>
+	</IfModule>
 </FilesMatch>

--- a/counter/.htaccess
+++ b/counter/.htaccess
@@ -1,7 +1,7 @@
-<IfVersion >= 2.4>
+<IfModule authz_host_module>
 	Require all denied
-</IfVersion>
-<IfVersion < 2.4>
+</IfModule>
+<IfModule !authz_host_module>
 	Order allow,deny
 	Deny from all
-</IfVersion>
+</IfModule>

--- a/diff/.htaccess
+++ b/diff/.htaccess
@@ -1,7 +1,7 @@
-<IfVersion >= 2.4>
+<IfModule authz_host_module>
 	Require all denied
-</IfVersion>
-<IfVersion < 2.4>
+</IfModule>
+<IfModule !authz_host_module>
 	Order allow,deny
 	Deny from all
-</IfVersion>
+</IfModule>

--- a/plugin/greybox/.htaccess
+++ b/plugin/greybox/.htaccess
@@ -1,7 +1,7 @@
-<IfVersion >= 2.4>
+<IfModule authz_host_module>
 	Require all granted
-</IfVersion>
-<IfVersion < 2.4>
+</IfModule>
+<IfModule !authz_host_module>
 	Order allow,deny
 	Allow from all
-</IfVersion>
+</IfModule>

--- a/plugin/lightbox2/.htaccess
+++ b/plugin/lightbox2/.htaccess
@@ -1,7 +1,7 @@
-<IfVersion >= 2.4>
+<IfModule authz_host_module>
 	Require all granted
-</IfVersion>
-<IfVersion < 2.4>
+</IfModule>
+<IfModule !authz_host_module>
 	Order allow,deny
 	Allow from all
-</IfVersion>
+</IfModule>

--- a/plugin/playlist/.htaccess
+++ b/plugin/playlist/.htaccess
@@ -1,7 +1,7 @@
-<IfVersion >= 2.4>
+<IfModule authz_host_module>
 	Require all granted
-</IfVersion>
-<IfVersion < 2.4>
+</IfModule>
+<IfModule !authz_host_module>
 	Order allow,deny
 	Allow from all
-</IfVersion>
+</IfModule>

--- a/swfu/.htaccess
+++ b/swfu/.htaccess
@@ -1,10 +1,10 @@
 # Prohibit direct access
 <FilesMatch "\.(ini\.php|lng\.php|txt|gz|tgz)$">
-	<IfVersion >= 2.4>
+	<IfModule authz_host_module>
 		Require all granted
-	</IfVersion>
-	<IfVersion < 2.4>
+	</IfModule>
+	<IfModule !authz_host_module>
 		Order allow,deny
 		Allow from all
-	</IfVersion>
+	</IfModule>
 </FilesMatch>

--- a/swfu/d/.htaccess
+++ b/swfu/d/.htaccess
@@ -1,9 +1,9 @@
 # Prohibit direct access
 <FilesMatch "\.(php[3457]?|pht|phtml|cgi|pl|exe|com)$">
-	<IfVersion >= 2.4>
+	<IfModule authz_host_module>
 		Require all denied
-	</IfVersion>
-	<IfVersion < 2.4>
+	</IfModule>
+	<IfModule !authz_host_module>
 		Deny from all
-	</IfVersion>
+	</IfModule>
 </FilesMatch>

--- a/trackback/.htaccess
+++ b/trackback/.htaccess
@@ -1,7 +1,7 @@
-<IfVersion >= 2.4>
+<IfModule authz_host_module>
 	Require all denied
-</IfVersion>
-<IfVersion < 2.4>
+</IfModule>
+<IfModule !authz_host_module>
 	Order allow,deny
 	Deny from all
-</IfVersion>
+</IfModule>

--- a/wiki/.htaccess
+++ b/wiki/.htaccess
@@ -1,7 +1,7 @@
-<IfVersion >= 2.4>
+<IfModule authz_host_module>
 	Require all denied
-</IfVersion>
-<IfVersion < 2.4>
+</IfModule>
+<IfModule !authz_host_module>
 	Order allow,deny
 	Deny from all
-</IfVersion>
+</IfModule>


### PR DESCRIPTION
## 概要
Close #93 
- `IfVersion` ディレクティブが利用できないサーバーがある
- バージョンではなく、 `mod_authz_host` モジュールの有無で分岐するように修正

## テスト方法

[ここ](https://github.com/open-qhm/qhm/archive/feature/%2393-htaccess.zip)からこのブランチをダウンロードし、各サーバー環境へ展開、正常に動作するか検証する。
検証項目

1. トップページの表示ができる（サーバーエラーにならない）
2. SWFUにアップした画像の表示ができる
3. 禁止ファイルへのアクセスができない 
    - `/lng.ja.txt`
    - `/cache/index.html`
    - `/backup/46726F6E7450616765.gz`
    - `/wiki/46726F6E7450616765.txt`
    - `/swfu/data/image.txt`

- [ ] Xserver
- [ ] さくらのレンタルサーバー
- [ ] ロリポップ

## タスク

- [ ] レビュー
- [ ] パッチバージョンアップ
- [ ] リリース
- [ ] 更新ファイル生成