### PR TITLE
Revert #89

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -2,23 +2,13 @@
 
 # Prohibit direct access
 <FilesMatch "\.(ini\.php|lng\.php|txt|gz|tgz)$">
-	<IfVersion >= 2.4>
-		Require all denied
-	</IfVersion>
-	<IfVersion < 2.4>
-		Order allow,deny
-		Deny from all
-	</IfVersion>
+	Order allow,deny
+	Deny from all
 </FilesMatch>
 
 <FilesMatch "^robots.txt$">
-	<IfVersion >= 2.4>
-		Require all granted
-	</IfVersion>
-	<IfVersion < 2.4>
-		Order allow,deny
-		Allow from all
-	</IfVersion>
+	Order allow,deny
+	Allow from all
 </FilesMatch>
 
 ## Add Content-Type for web-fonts and videos

--- a/attach/.htaccess
+++ b/attach/.htaccess
@@ -1,7 +1,2 @@
-<IfVersion >= 2.4>
-	Require all denied
-</IfVersion>
-<IfVersion < 2.4>
-	Order allow,deny
-	Deny from all
-</IfVersion>
+Order allow,deny
+Deny from all

--- a/backup/.htaccess
+++ b/backup/.htaccess
@@ -1,7 +1,2 @@
-<IfVersion >= 2.4>
-	Require all denied
-</IfVersion>
-<IfVersion < 2.4>
-	Order allow,deny
-	Deny from all
-</IfVersion>
+Order allow,deny
+Deny from all

--- a/cache/.htaccess
+++ b/cache/.htaccess
@@ -1,17 +1,7 @@
-<IfVersion >= 2.4>
-	Require all denied
-</IfVersion>
-<IfVersion < 2.4>
-	Order allow,deny
-	Deny from all
-</IfVersion>
+Order allow,deny
+Deny from all
 
 # Amazon plugin's Image cache
 <FilesMatch ".*\.(jpg|JPG|png|PNG|gif|GIF|jpeg|JPEG)$">
-	<IfVersion >= 2.4>
-		Require all granted
-	</IfVersion>
-	<IfVersion < 2.4>
-		Allow from all
-	</IfVersion>
+	Allow from all
 </FilesMatch>

--- a/counter/.htaccess
+++ b/counter/.htaccess
@@ -1,7 +1,2 @@
-<IfVersion >= 2.4>
-	Require all denied
-</IfVersion>
-<IfVersion < 2.4>
-	Order allow,deny
-	Deny from all
-</IfVersion>
+Order allow,deny
+Deny from all

--- a/diff/.htaccess
+++ b/diff/.htaccess
@@ -1,7 +1,2 @@
-<IfVersion >= 2.4>
-	Require all denied
-</IfVersion>
-<IfVersion < 2.4>
-	Order allow,deny
-	Deny from all
-</IfVersion>
+Order allow,deny
+Deny from all

--- a/plugin/greybox/.htaccess
+++ b/plugin/greybox/.htaccess
@@ -1,7 +1,2 @@
-<IfVersion >= 2.4>
-	Require all granted
-</IfVersion>
-<IfVersion < 2.4>
-	Order allow,deny
-	Allow from all
-</IfVersion>
+Order allow,deny
+allow from all

--- a/plugin/lightbox2/.htaccess
+++ b/plugin/lightbox2/.htaccess
@@ -1,7 +1,2 @@
-<IfVersion >= 2.4>
-	Require all granted
-</IfVersion>
-<IfVersion < 2.4>
-	Order allow,deny
-	Allow from all
-</IfVersion>
+Order allow,deny
+allow from all

--- a/plugin/playlist/.htaccess
+++ b/plugin/playlist/.htaccess
@@ -1,7 +1,2 @@
-<IfVersion >= 2.4>
-	Require all granted
-</IfVersion>
-<IfVersion < 2.4>
-	Order allow,deny
-	Allow from all
-</IfVersion>
+Order allow,deny
+allow from all

--- a/swfu/.htaccess
+++ b/swfu/.htaccess
@@ -1,10 +1,5 @@
 # Prohibit direct access
 <FilesMatch "\.(ini\.php|lng\.php|txt|gz|tgz)$">
-	<IfVersion >= 2.4>
-		Require all granted
-	</IfVersion>
-	<IfVersion < 2.4>
-		Order allow,deny
-		Allow from all
-	</IfVersion>
+	Order allow,deny
+	Allow from all
 </FilesMatch>

--- a/swfu/d/.htaccess
+++ b/swfu/d/.htaccess
@@ -1,9 +1,4 @@
 # Prohibit direct access
 <FilesMatch "\.(php[3457]?|pht|phtml|cgi|pl|exe|com)$">
-	<IfVersion >= 2.4>
-		Require all denied
-	</IfVersion>
-	<IfVersion < 2.4>
-		Deny from all
-	</IfVersion>
+    Deny from all
 </FilesMatch>

--- a/trackback/.htaccess
+++ b/trackback/.htaccess
@@ -1,7 +1,2 @@
-<IfVersion >= 2.4>
-	Require all denied
-</IfVersion>
-<IfVersion < 2.4>
-	Order allow,deny
-	Deny from all
-</IfVersion>
+Order allow,deny
+Deny from all

--- a/wiki/.htaccess
+++ b/wiki/.htaccess
@@ -1,7 +1,2 @@
-<IfVersion >= 2.4>
-	Require all denied
-</IfVersion>
-<IfVersion < 2.4>
-	Order allow,deny
-	Deny from all
-</IfVersion>
+Order allow,deny
+Deny from all


### PR DESCRIPTION
## 概要

- Apache 2.4以上と Apache 2.4 未満の両方で動くアクセス制御の記述はサーバーによって動作しないことがあった
- #93 で解決方法を模索したが、 .htaccess で表現することは難しく断念。一旦 #89 をリバートする
- Apache 2.4 以上でも `mod_access_compat` があれば引き続き `Order` が使えるので多くのサーバーでは致命的では無いはず

## タスク

- [x] レビュー
- [x] パッチバージョンアップ
- [ ] リリース
- [ ] 更新ファイル