### PR TITLE
FontAwesome 5 を読み込む

### DIFF
--- a/lib/qhm_init.php
+++ b/lib/qhm_init.php
@@ -271,12 +271,12 @@ EOD;
 	),
 	'haikskincustomizer' => array('name'=>'テーマ編集', 'link'=>$link_haik_skin_customizer, 'style'=>'margin-top:1.1em;', 'class'=>'', 'visible'=>TRUE),
   'haikpreviewlinks' => array('name'=>'プレビュー', 'link'=>'', 'visible'=>TRUE, 'sub'=>array(
-      'mobilesm' => array('name'=>'<i class="fa fa-lg fa-mobile" aria-hidden="true"></i><span class="sr-only">モバイル</span> 4.0 inch',  'link'=>'#', 'visible'=>TRUE),
-      'mobilemd' => array('name'=>'<i class="fa fa-lg fa-mobile" aria-hidden="true"></i><span class="sr-only">モバイル</span> 4.7 inch',  'link'=>'#', 'visible'=>TRUE),
-      'mobilelg' => array('name'=>'<i class="fa fa-lg fa-mobile" aria-hidden="true"></i><span class="sr-only">モバイル</span> 5.5 inch',  'link'=>'#', 'visible'=>TRUE),
-      'tablet' => array('name'=>'<i class="fa fa-lg fa-tablet" aria-hidden="true"></i> Tablet', 'link'=>'#', 'visible'=>TRUE),
-      'laptop' => array('name'=>'<i class="fa fa-lg fa-laptop" aria-hidden="true"></i><span class="sr-only">デスクトップ</span> 1366×768',  'link'=>'#', 'visible'=>TRUE),
-      'desktop' => array('name'=>'<i class="fa fa-lg fa-desktop" aria-hidden="true"></i><span class="sr-only">モバイル</span> 1920×1080', 'link'=>'#', 'visible'=>TRUE),
+      'mobilesm' => array('name'=>'<i class="fa fa-lg fa-fw fa-mobile" aria-hidden="true"></i><span class="sr-only">モバイル</span> 4.0 inch',  'link'=>'#', 'visible'=>TRUE),
+      'mobilemd' => array('name'=>'<i class="fa fa-lg fa-fw fa-mobile" aria-hidden="true"></i><span class="sr-only">モバイル</span> 4.7 inch',  'link'=>'#', 'visible'=>TRUE),
+      'mobilelg' => array('name'=>'<i class="fa fa-lg fa-fw fa-mobile" aria-hidden="true"></i><span class="sr-only">モバイル</span> 5.5 inch',  'link'=>'#', 'visible'=>TRUE),
+      'tablet' => array('name'=>'<i class="fa fa-lg fa-fw fa-tablet" aria-hidden="true"></i> Tablet', 'link'=>'#', 'visible'=>TRUE),
+      'laptop' => array('name'=>'<i class="fa fa-lg fa-fw fa-laptop" aria-hidden="true"></i><span class="sr-only">デスクトップ</span> 1366×768',  'link'=>'#', 'visible'=>TRUE),
+      'desktop' => array('name'=>'<i class="fa fa-lg fa-fw fa-desktop" aria-hidden="true"></i><span class="sr-only">モバイル</span> 1920×1080', 'link'=>'#', 'visible'=>TRUE),
     )
   ),
 

--- a/lib/qhm_init_main.php
+++ b/lib/qhm_init_main.php
@@ -99,9 +99,12 @@ if ($is_bootstrap_skin)
         $bootstrap_css .= '<link rel="stylesheet" href="'.SKIN_DIR.$style_name.'/base.css">';
     }
     $bootstrap_script = '<script type="text/javascript" src="skin/bootstrap/js/bootstrap.min.js"></script>';
-    //FontAwesome
-    $bootstrap_script .= '<script src="//maxcdn.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css"></script>';
     $qt->setv('bootstrap_script', $bootstrap_script);
+    //FontAwesome
+    if (exist_plugin('icon'))
+    {
+        plugin_icon_set_font_awesome();
+    }
 }
 
 // CSSの生成

--- a/plugin/icon.inc.php
+++ b/plugin/icon.inc.php
@@ -57,8 +57,9 @@ function plugin_icon_inline()
 function plugin_icon_set_font_awesome()
 {
     $qt = get_qt();
-    $addcss = '
-<link href="//maxcdn.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" rel="stylesheet">
-';
+    $addcss = <<<HTML
+<script defer src="https://use.fontawesome.com/releases/v5.0.6/js/all.js"></script>
+<script defer src="https://use.fontawesome.com/releases/v5.0.6/js/v4-shims.js"></script>
+HTML;
     $qt->appendv_once('plugin_icon_font_awesome', 'beforescript', $addcss);
 }

--- a/plugin/icon.inc.php
+++ b/plugin/icon.inc.php
@@ -32,13 +32,20 @@ function plugin_icon_inline()
 			$icon_base = 'glyphicon';
 			$icon_prefix = $icon_base . '-';
 		}
+		// FontAwesome 4 系互換の記述
 		if ($arg === 'font-awesome' OR $arg === 'fa')
 		{
 			$icon_base = 'fa';
 			$icon_prefix = $icon_base . '-';
 			plugin_icon_set_font_awesome();
 		}
-		else if ($icon_base === 'fa' && preg_match('/^[1-5]x|lg$/', $arg))
+		// FontAwesome 5
+		else if (preg_match('/^(fa[bsrl])$/', $arg)) {
+			$icon_base = $arg;
+			$icon_prefix = 'fa-';
+			plugin_icon_set_font_awesome();
+		}
+		else if (preg_match('/^fa[bsrl]?$/', $icon_base) && preg_match('/^[1-5]x|lg$/', $arg))
 		{
 			$icon_options = " {$icon_prefix}{$arg}";
 		}

--- a/plugin/icon.inc.php
+++ b/plugin/icon.inc.php
@@ -34,13 +34,13 @@ function plugin_icon_inline()
 		}
 		if ($arg === 'font-awesome' OR $arg === 'fa')
 		{
-    		$icon_base = 'fa';
-    		$icon_prefix = $icon_base . '-';
-    		plugin_icon_set_font_awesome();
+			$icon_base = 'fa';
+			$icon_prefix = $icon_base . '-';
+			plugin_icon_set_font_awesome();
 		}
 		else if ($icon_base === 'fa' && preg_match('/^[1-5]x|lg$/', $arg))
 		{
-    		$icon_options = " {$icon_prefix}{$arg}";
+			$icon_options = " {$icon_prefix}{$arg}";
 		}
 		else if ($arg !== '')
 		{
@@ -56,10 +56,10 @@ function plugin_icon_inline()
 
 function plugin_icon_set_font_awesome()
 {
-    $qt = get_qt();
-    $addcss = <<<HTML
+	$qt = get_qt();
+	$addcss = <<<HTML
 <script defer src="https://use.fontawesome.com/releases/v5.0.6/js/all.js"></script>
 <script defer src="https://use.fontawesome.com/releases/v5.0.6/js/v4-shims.js"></script>
 HTML;
-    $qt->appendv_once('plugin_icon_font_awesome', 'beforescript', $addcss);
+	$qt->appendv_once('plugin_icon_font_awesome', 'beforescript', $addcss);
 }

--- a/plugin/icon.inc.php
+++ b/plugin/icon.inc.php
@@ -45,7 +45,7 @@ function plugin_icon_inline()
 			$icon_prefix = 'fa-';
 			plugin_icon_set_font_awesome();
 		}
-		else if (preg_match('/^fa[bsrl]?$/', $icon_base) && preg_match('/^[1-5]x|lg$/', $arg))
+		else if (preg_match('/^fa[bsrl]?$/', $icon_base) && preg_match('/^[1-5]x|lg|fw$/', $arg))
 		{
 			$icon_options = " {$icon_prefix}{$arg}";
 		}

--- a/plugin/section.inc.php
+++ b/plugin/section.inc.php
@@ -252,7 +252,7 @@ function plugin_section_convert()
         {
             $attrs['data-filter'] = $filter;
             $svg_html = '
-<svg version="1.1" xmlns="http://www.w3.org/2000/svg">
+<svg class="qhm-section-filter" version="1.1" xmlns="http://www.w3.org/2000/svg">
   <filter id="blur">
     <feGaussianBlur stdDeviation="6" />
   </filter>

--- a/plugin/section/section.css
+++ b/plugin/section/section.css
@@ -168,7 +168,7 @@
   bottom:0;
   left: 0;
 }
-svg {
+.qhm-section-filter {
   width: 0;
   height: 0;
   position: absolute;


### PR DESCRIPTION
## 概要

Ref #96 
- FontAwesome 5 のアイコンを利用できるようにした
- FontAwesome 4 のアイコンについては利用できなくなる
- ただし、公式提供の Shim を利用しているので、従来の書き方はそのまま使える
- [FA4 → FA5の対応表はこちら](https://fontawesome.com/how-to-use/upgrading-from-4)

## テスト方法

- 従来のアイコンが使えることを確認
- FA5 以降に追加されたアイコンが使えることを確認

```
// FA4 までの書き方
&icon(fa,music); `fa,music`

// FA5 から追加されたアイコン
&icon(fab,line); `fab,line`

// FA5 で追加されたプレフィクスクラスを利用したユーザーアイコン
&icon(fas,user); `fas,user`
&icon(far,user); `far,user`
```

## スクリーンショット
<img width="165" alt="2018-02-12 23 51 30" src="https://user-images.githubusercontent.com/808888/36102434-ad62e17e-104f-11e8-933e-b274c3b1269a.png">