### PR TITLE
閉鎖時のQHM表記を修正

### DIFF
--- a/lib/func.php
+++ b/lib/func.php
@@ -973,7 +973,7 @@ function output_site_close_message($site_name, $login_url)
 {
 	global $qhm_adminmenu;
 
-	$qhm_sign = ($qhm_adminmenu < 2) ? '<a href="'. h($login_url) . '">QHM</a>' : 'QHM';
+	$qhm_sign = ($qhm_adminmenu < 2) ? '<a href="'. h($login_url) . '">HAIK</a>' : 'HAIK';
 
 	pkwk_common_headers();
 	$qm = get_qm();


### PR DESCRIPTION
## 概要
Close #102 
- QHM → HAIK

## スクリーンショット
<img width="566" alt="2018-02-22 6 54 17" src="https://user-images.githubusercontent.com/808888/36507573-77667252-179d-11e8-8876-6079e1f5386f.png">

## タスク

- [ ] マージ

文言の修正なのでバージョン上げずにリリースします。