### PR TITLE
[plugin]search2 のアイコン表示を修正

### DIFF
--- a/lib/init.php
+++ b/lib/init.php
@@ -11,7 +11,7 @@
 // PukiWiki version / Copyright / Licence
 
 define('S_VERSION', '1.4.7');
-define('QHM_VERSION', '7.2.1');  //絶対に編集しないで下さい
+define('QHM_VERSION', '7.2.2');  //絶対に編集しないで下さい
 define('QHM_OPTIONS', 'update=download; support=false; banner=true');
 define('S_COPYRIGHT',
 	'powered by <strong><a href="http://www.open-qhm.net/">HAIK</a> ' . QHM_VERSION . '</strong><br />' .

--- a/plugin/icon.inc.php
+++ b/plugin/icon.inc.php
@@ -61,12 +61,27 @@ function plugin_icon_inline()
 	return sprintf($format, h($icon_base), h($icon_name), $icon_options);
 }
 
-function plugin_icon_set_font_awesome()
+/**
+ * FontAwesome 5 を読みこむ
+ *
+ * @param boolean $search_pseudo_elements CSS Pseudo Elements を利用するかどうか
+ * @see https://fontawesome.com/how-to-use/svg-with-js#pseudo-elements
+ */
+function plugin_icon_set_font_awesome($search_pseudo_elements = false)
 {
 	$qt = get_qt();
-	$addcss = <<<HTML
+	$js = <<<HTML
 <script defer src="https://use.fontawesome.com/releases/v5.0.6/js/all.js"></script>
 <script defer src="https://use.fontawesome.com/releases/v5.0.6/js/v4-shims.js"></script>
 HTML;
-	$qt->appendv_once('plugin_icon_font_awesome', 'beforescript', $addcss);
+    // CSS Pseudo-elements を利用する場合
+    if ($search_pseudo_elements) {
+        $extrajs = <<< HTML
+<script>
+  FontAwesomeConfig = { searchPseudoElements: true };
+</script>
+HTML;
+        $qt->prependv_once('plugin_icon_font_awesome_pseudo_elements', 'beforescript', $extrajs);
+    }
+	$qt->appendv_once('plugin_icon_font_awesome', 'beforescript', $js);
 }

--- a/plugin/search2.inc.php
+++ b/plugin/search2.inc.php
@@ -156,29 +156,31 @@ EOD;
     $style = '';
     if (exist_plugin('icon'))
     {
-        plugin_icon_set_font_awesome();
-        $style = '
+        plugin_icon_set_font_awesome(true);
+        $style = <<< HTML
 <style>
 [data-plugin=search2] > div.input-group,
 [data-plugin=search2] > div.form-group {
-    position: relative;
+  position: relative;
 }
-[data-plugin=search2] > div.input-group:before,
-[data-plugin=search2] > div.form-group:before {
-    font-family: FontAwesome;
-    content: "\f002";
-    position:absolute;
-    top:8px;
-    left:10px;
-    z-index: 3;
-    color: #999;
-    line-height: 1.42857143;
+[data-plugin=search2] > div.input-group::before,
+[data-plugin=search2] > div.form-group::before {
+  display: none;
+  font-family: "Font Awesome 5 Solid";
+  content: "\\f002";
 }
-[data-plugin=search2] input[type=text] {
-    padding-left:30px;
+[data-plugin=search2] .svg-inline--fa {
+  position: absolute;
+  top: 13px;
+  left: 10px;
+  z-index: 5;
+  color: #999;
+}
+[data-plugin=search2] input[type="text"] {
+  padding-left: 30px;
 }
 </style>
-';
+HTML;
     }
 
     $qt->appendv_once("plugin_search2_style", "beforescript", $style);

--- a/plugin/search2.inc.php
+++ b/plugin/search2.inc.php
@@ -159,12 +159,12 @@ EOD;
         plugin_icon_set_font_awesome(true);
         $style = <<< HTML
 <style>
-[data-plugin=search2] > div.input-group,
-[data-plugin=search2] > div.form-group {
+[data-plugin=search2] > .input-group,
+[data-plugin=search2] > .form-group {
   position: relative;
 }
-[data-plugin=search2] > div.input-group::before,
-[data-plugin=search2] > div.form-group::before {
+[data-plugin=search2] > .input-group::before,
+[data-plugin=search2] > .form-group::before {
   display: none;
   font-family: "Font Awesome 5 Solid";
   content: "\\f002";
@@ -175,6 +175,14 @@ EOD;
   left: 10px;
   z-index: 5;
   color: #999;
+}
+[data-plugin=search2] .input-group .svg-inline--fa {
+  top: 13px;
+  left: 10px;
+}
+[data-plugin=search2] .form-group .svg-inline--fa {
+  top: 10px;
+  left: 10px;
 }
 [data-plugin=search2] input[type="text"] {
   padding-left: 30px;


### PR DESCRIPTION
## 概要

- `#search2` の表示が壊れていたので修正
- FontAwesome 5 の新しい作法に対応した
- `::before` 疑似要素が `<svg>` に変換されるのでそれに対してスタイルを適用する

## スクリーンショット

本文
<img width="639" alt="2018-02-22 22 45 14" src="https://user-images.githubusercontent.com/808888/36541928-d3e1777c-1822-11e8-9687-2a7ba9d026b3.png">

メニュー
<img width="244" alt="2018-02-22 22 50 00" src="https://user-images.githubusercontent.com/808888/36541935-d8f3e4f2-1822-11e8-98f6-7b775a8f760a.png">


## テスト方法

1. 本文中、メニューに `#search2` を設置して表示を確認する
    ```
    // 本文
    #search2
    
    // メニュー
    #search2(compact)
    ```
2. フォーカスを当てる、文字を入力するなどして表示に問題が無いか確認する

## タスク

- [x] レビュー
- [x] パッチバージョンアップ
- [ ] マージ
- [ ] リリース
- [ ] 更新ファイル

