### PR TITLE
CircleCI を利用して自動的にリリースを作成する

### DIFF
--- a/.circleci/build-update-file
+++ b/.circleci/build-update-file
@@ -1,0 +1,55 @@
+# !/bin/bash
+
+###############################
+#
+# Build Script for QHM Update Package
+#
+###############################
+
+
+## Remove Files of dist dir
+# @param string dist path
+function remove_data_files {
+  local paths=(.htaccess qhm.ini.php qhm_access.ini.txt qhm_users.ini.txt attach backup cache cacheqblog cacheqhm counter diff fwd3/sys/data skin/wordpress skin/hokukenstyle/*/ trackback wiki swfu/data swfu/d .circleci)
+  for path in "${paths[@]}"
+  do
+    echo "Remove $1/$path"
+    rm -rf "$1/$path"
+  done
+
+  # touch empty file to cacheqblog and cacheqhm
+  mkdir "$1/cacheqhm" && touch "$1/cacheqhm/index.html"
+  mkdir "$1/cacheqblog" && touch "$1/cacheqblog/index.html"
+  echo
+}
+
+
+#
+# Main
+#
+
+#1. ファイルをコピーする
+#2. 不要なファイルを削除
+#3. zip アーカイブ→生成物ディレクトリ
+
+#
+# Build Package
+#
+
+QHM_VERSION=$(grep "define('QHM_VERSION" lib/init.php | cut -d "'" -f 4)
+echo "Build QHM v$QHM_VERSION's update file."
+
+mkdir tmp
+
+git archive HEAD --output=tmp/qhm.tar.gz --prefix="tmp/update_$QHM_VERSION/"
+tar -zxvf tmp/qhm.tar.gz
+
+remove_data_files "tmp/update_$QHM_VERSION"
+
+cd tmp
+mkdir build
+zip -r "build/update_$QHM_VERSION.zip" "update_$QHM_VERSION"
+
+echo
+echo "Complete Build QHM v$QHM_VERSION's update file."
+echo

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -41,4 +41,4 @@ workflows:
             - build
           filters:
             branches:
-              only: feature/circleci
+              only: master

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,44 @@
+# PHP CircleCI 2.0 configuration file
+#
+# Check https://circleci.com/docs/2.0/language-php/ for more details
+#
+version: 2
+jobs:
+  build:
+    docker:
+      - image: circleci/php:7.1.5-browsers
+    working_directory: ~/repo
+    steps:
+      - checkout
+      - run: .circleci/build-update-file
+      - store_artifacts:
+          path: tmp/build
+      - persist_to_workspace:
+          root: tmp
+          paths:
+            - build
+
+  release:
+    docker:
+      - image: circleci/golang:1.10
+    working_directory: ~/repo
+    steps:
+      - checkout
+      - run: go get github.com/aktau/github-release
+      - attach_workspace:
+          at: tmp
+      - run: .circleci/release
+workflows:
+  version: 2
+  build-and-release:
+    jobs:
+      - build:
+          filters:
+            tags:
+              only: /.*/
+      - release:
+          requires:
+            - build
+          filters:
+            branches:
+              only: feature/circleci

--- a/.circleci/release
+++ b/.circleci/release
@@ -1,0 +1,47 @@
+# !/bin/bash
+
+###############################
+#
+# Release Tag to GitHub
+#
+###############################
+
+VERSION=$(grep "define('QHM_VERSION" lib/init.php | cut -d "'" -f 4)
+VTEXT="v$VERSION"
+
+# re-tag
+git tag | grep $VTEXT
+if [ $? = 0 ]; then
+  git tag --delete $VTEXT
+  git push --delete origin $VTEXT
+fi
+git tag $VTEXT
+git push origin $VTEXT
+
+github-release info \
+  --user $CIRCLE_PROJECT_USERNAME \
+  --repo $CIRCLE_PROJECT_REPONAME \
+  --tag $VTEXT
+if [ $? = 1 ]; then
+  subcommand=release
+else
+  subcommand=edit
+fi
+
+# create release
+github-release $subcommand \
+  --user $CIRCLE_PROJECT_USERNAME \
+  --repo $CIRCLE_PROJECT_REPONAME \
+  --tag $VTEXT \
+  --name $VTEXT \
+  --description "手動更新には「更新ファイル」をダウンロードしてご利用ください。"
+
+# upload files
+github-release upload \
+  --user $CIRCLE_PROJECT_USERNAME \
+  --repo $CIRCLE_PROJECT_REPONAME \
+  --tag $VTEXT \
+  --label "更新ファイル" \
+  --name "qhm-${VERSION}_update.zip" \
+  --file "tmp/build/update_$VERSION.zip" \
+  --replace


### PR DESCRIPTION
## 概要

- 今まで手動で行っていたリリース手順を自動化した
- 利用したCI サービスは CircleCI 2.0 
- 詳しいビルド内容は次項参照
- このPRをマージした以降は PR での作業が下記のようになる
    1. レビュー
    2. バージョンアップ（ `lib/init.php` の編集）
    3. マージ
- タグ付けと更新ファイル、Release の作成から解放された 🎊 
- HAIKの機能自体には変化ないのでバージョンは変わらない

### master 以外のブランチを push した場合
1. 更新ファイルのビルド `qhm-7.2.2_update.zip`
    ビルドされた更新ファイルは Build Artifact として保存される。
    GitHub で公開されるわけではないが、これは開発時のみ利用するので問題無い。

### master ブランチを push した場合
1. 更新ファイルのビルド `qhm-7.2.2_update.zip`
    ビルドされた更新ファイルは Build Artifact として保存される。
    後で GitHub Release へアップロードされる。
2. GitHub Release の作成
    現在記述されているバージョンで tag を切り直し、 GitHub Release を作成／更新する。
    (1) でビルドした更新ファイルを GitHub Release へアップロードする。

## 設定について補足など

- CIコンテナから git push をするために GitHub user key を登録した
    - Project Setting -> PERMISSIONS -> Checkout SSH keys で登録できる
- GitHub Release の操作は https://github.com/aktau/github-release を利用した
    - `GITHUB_TOKEN` 環境変数を登録しておく必要がある
        - Project Setting -> BUILD SETTINGS -> Environment Variables で登録できる
        - `GITHUB_TOKEN` は[GitHub のここ](https://github.com/settings/tokens)で発行できる


