### PR TITLE
IE,Edgeで #bs_carousel に #search2 が干渉しないよう修正

### DIFF
--- a/plugin/icon.inc.php
+++ b/plugin/icon.inc.php
@@ -63,6 +63,8 @@ function plugin_icon_inline()
 
 /**
  * FontAwesome 5 を読みこむ
+ * $search_pseudo_elements を true にすると、疑似要素にFontAwesomeを使えるが、
+ * IE, Edge で #bs_carousel が正常に動作しなくなる影響があるので解決するまで使わないこと。
  *
  * @param boolean $search_pseudo_elements CSS Pseudo Elements を利用するかどうか
  * @see https://fontawesome.com/how-to-use/svg-with-js#pseudo-elements
@@ -71,8 +73,8 @@ function plugin_icon_set_font_awesome($search_pseudo_elements = false)
 {
 	$qt = get_qt();
 	$js = <<<HTML
-<script defer src="https://use.fontawesome.com/releases/v5.0.6/js/all.js"></script>
-<script defer src="https://use.fontawesome.com/releases/v5.0.6/js/v4-shims.js"></script>
+<script defer src="https://use.fontawesome.com/releases/v5.0.9/js/all.js"></script>
+<script defer src="https://use.fontawesome.com/releases/v5.0.9/js/v4-shims.js"></script>
 HTML;
     // CSS Pseudo-elements を利用する場合
     if ($search_pseudo_elements) {

--- a/plugin/search2.inc.php
+++ b/plugin/search2.inc.php
@@ -132,6 +132,7 @@ EOD;
   <input type="hidden" name="cmd" value="search2" />
   <input type="hidden" name="type" value="AND" />
   <div class="form-group">
+    <i class="fas fa-search"></i>
     <input type="text"  name="word" value="'.h($s_word).'" class="form-control" placeholder="検索ワード" />
   </div>
 </form>
@@ -156,36 +157,24 @@ EOD;
     $style = '';
     if (exist_plugin('icon'))
     {
-        plugin_icon_set_font_awesome(true);
+        plugin_icon_set_font_awesome();
         $style = <<< HTML
 <style>
 [data-plugin=search2] > .input-group,
 [data-plugin=search2] > .form-group {
   position: relative;
 }
-[data-plugin=search2] > .input-group::before,
-[data-plugin=search2] > .form-group::before {
-  display: none;
-  font-family: "Font Awesome 5 Solid";
-  content: "\\f002";
-}
-[data-plugin=search2] .svg-inline--fa {
+[data-plugin=search2] > .form-group > .svg-inline--fa {
   position: absolute;
-  top: 13px;
-  left: 10px;
-  z-index: 5;
-  color: #999;
-}
-[data-plugin=search2] .input-group .svg-inline--fa {
-  top: 13px;
-  left: 10px;
-}
-[data-plugin=search2] .form-group .svg-inline--fa {
   top: 10px;
-  left: 10px;
+  left: 9px;
+  color: #999;
 }
 [data-plugin=search2] input[type="text"] {
   padding-left: 30px;
+}
+[data-plugin=search2] input[type="text"]:-ms-input-placeholder {
+  line-height: 24px;
 }
 </style>
 HTML;


### PR DESCRIPTION
## 概要
Close #114 

- IE, Edge で `#bs_carousel` が正常に動作しない場合がある
- 同じページ上に `#search2` が存在すると挙動がおかしくなる
- FontAwesome の `SearchPseudoElements` オプションが有効な時に干渉するようなのでこれを使わないよう回避した

## テスト方法

1. 同じページに `#bs_carousel` と `#search2` を設置する
2. `#bs_carousel` は複数枚の画像を指定する
3. IE, Edge で動作確認し、全ての画像が正常表示されればOK

## タスク

- [ ] レビュー
- [ ] パッチバージョンアップ
