### PR TITLE
プラグインが参照するリソースをrelative protocolに変更

### DIFF
--- a/lib/init.php
+++ b/lib/init.php
@@ -11,7 +11,7 @@
 // PukiWiki version / Copyright / Licence
 
 define('S_VERSION', '1.4.7');
-define('QHM_VERSION', '7.2.4');  //絶対に編集しないで下さい
+define('QHM_VERSION', '7.2.5');  //絶対に編集しないで下さい
 define('QHM_OPTIONS', 'update=download; support=false; banner=true');
 define('S_COPYRIGHT',
 	'powered by <strong><a href="https://haik-cms.jp/">HAIK</a> ' . QHM_VERSION . '</strong><br />' .

--- a/plugin/qr.inc.php
+++ b/plugin/qr.inc.php
@@ -3,13 +3,13 @@
  *   QR-Code Generator Plugin
  *   -------------------------------------------
  *   qr.inc.php
- *   
+ *
  *   Copyright (c) 2010 hokuken
  *   http://hokuken.com/
- *   
+ *
  *   created  : 2010-08-18
  *   modified :
- *   
+ *
  *   USAGE:
  *     inline plugin:
  *       &qr(string[, width[, height[,encoding]]);
@@ -19,7 +19,7 @@
  *       &qr(url);
  */
 
-define('PLUGIN_QR_URL_FORMAT', 'http://chart.apis.google.com/chart?chs=%WIDTH%x%HEIGHT%&cht=qr&chl=%STRING%%ENCODING%');
+define('PLUGIN_QR_URL_FORMAT', '//chart.apis.google.com/chart?chs=%WIDTH%x%HEIGHT%&cht=qr&chl=%STRING%%ENCODING%');
 define('PLUGIN_QR_DISP_FORMAT', '<img src="%CHURL%">');
 define('PLUGIN_QR_DESP_URL_FORMAT', '<input type="text" value="%URL%" size="10" style="width:10em" onclick="this.focus();this.select();" readonly="readonly" />');
 define('PLUGIN_QR_DEFAULT_SIZE', 150);
@@ -31,17 +31,17 @@ function plugin_qr_inline() {
 	$args = func_get_args();
 	//first param is string
 	$str = array_shift($args);
-	
+
 	$w = $h = PLUGIN_QR_DEFAULT_SIZE;
 	$enc = '';
 	$encs = plugin_qr_get_encs();
-	
+
 	if ($str == 'url') {
 		$url = $script. '?page='. rawurlencode($page). '&plugin=qr';
-		
+
 		return str_replace('%URL%', $url, PLUGIN_QR_DESP_URL_FORMAT);
 	}
-	
+
 	$sizecnt = 0;
 	foreach ($args as $arg) {
 		if ($sizecnt === 0 && preg_match('/^(\d+)$/', trim($arg))) {
@@ -57,9 +57,9 @@ function plugin_qr_inline() {
 	}
 
 	$churl = plugin_qr_gen_qrcode($str, $w, $h, $enc);
-	
+
 	$chimg = str_replace('%CHURL%', $churl, PLUGIN_QR_DISP_FORMAT);
-	
+
 	return $chimg;
 
 }
@@ -72,9 +72,9 @@ function plugin_qr_action() {
 	$w = isset($vars['w'])? $vars['w']: PLUGIN_QR_DEFAULT_SIZE;
 	$h = isset($vars['h'])? $vars['h']: PLUGIN_QR_DEFAULT_SIZE;
 	$enc = isset($vars['enc']) && in_array($vars['enc'], plugin_qr_get_encs())? $vars['enc']: '';
-	
+
 	$churl = plugin_qr_gen_qrcode($str, $w, $h, $enc);
-	
+
 	if ($fp = fopen($churl, 'rb')) {
 		$qr = '';
 		while (!feof($fp)) {
@@ -82,9 +82,9 @@ function plugin_qr_action() {
 		}
 		fclose($fp);
 	}
-	
+
 	$imgsize = strlen($qr);
-	
+
 	//画像を出力
 	header('Content-Length: ' . $imgsize);
 	header('Content-Type: image/png');
@@ -98,7 +98,7 @@ function plugin_qr_gen_qrcode($str, $w=PLUGIN_QR_DEFAULT_SIZE, $h=PLUGIN_QR_DEFA
 	$ptns = array('%STRING%', '%WIDTH%', '%HEIGHT%', '%ENCODING%');
 	$rpls = array($str, $w, $h, $enc);
 	$churl = str_replace($ptns, $rpls, PLUGIN_QR_URL_FORMAT);
-	
+
 	return $churl;
 
 
@@ -107,5 +107,3 @@ function plugin_qr_gen_qrcode($str, $w=PLUGIN_QR_DEFAULT_SIZE, $h=PLUGIN_QR_DEFA
 function plugin_qr_get_encs() {
 	return array('Shift_JIS', 'ISO-8859-1');
 }
-
-?>

--- a/plugin/skin_customizer.inc.php
+++ b/plugin/skin_customizer.inc.php
@@ -14,7 +14,7 @@
  *
  */
 
-define('PLUGIN_SKIN_CUSTOMIZER_CDN', 'http://open-qhm.github.io/haik-parts');
+define('PLUGIN_SKIN_CUSTOMIZER_CDN', 'https://open-qhm.github.io/haik-parts');
 function plugin_skin_customizer_action()
 {
     global $vars, $script;
@@ -268,8 +268,8 @@ function plugin_skin_customizer_set_form()
                 break;
 
             case 'select_img':
-                $host = PLUGIN_SKIN_CUSTOMIZER_CDN;
-                $haik_bg_images = file_get_contents("{$host}/data/images.json");
+                $host = ltrim(PLUGIN_SKIN_CUSTOMIZER_CDN, 'https:');
+                $haik_bg_images = file_get_contents(PLUGIN_SKIN_CUSTOMIZER_CDN . '/data/images.json');
                 $haik_bg_images = json_decode($haik_bg_images, true);
                 foreach ($haik_bg_images as $i => $bg_image)
                 {
@@ -301,8 +301,8 @@ function plugin_skin_customizer_set_form()
                 break;
 
             case 'select_texture':
-                $host = PLUGIN_SKIN_CUSTOMIZER_CDN;
-                $haik_bg_images = file_get_contents("{$host}/data/textures.json");
+                $host = ltrim(PLUGIN_SKIN_CUSTOMIZER_CDN, 'https:');
+                $haik_bg_images = file_get_contents(PLUGIN_SKIN_CUSTOMIZER_CDN . '/data/textures.json');
                 $haik_bg_images = json_decode($haik_bg_images, true);
                 foreach ($haik_bg_images as $i => $bg_image)
                 {


### PR DESCRIPTION
## 概要
Close #113 
- QRコードとテーマ編集で使える背景画像やテクスチャを relative protocol `e.g. //example.com/path/to/file` に変更
- HTTPS 接続に対応完了
    - 対応しないプラグインについてはこちら参照 https://github.com/open-qhm/qhm/issues/113#issuecomment-378264626

## テスト方法

### QR

1. QRコードを設置する `&qr(url);`
2. HTTPで画像が正常に表示されるか確認
3. HTTPS で画像が正常に表示されるか確認

### テーマ編集
アイキャッチ背景画像を使用する→画像選択
1. HTTPで画像リストが表示されるか確認
2. HTTPSで画像リストが表示されるか確認

## タスク

- [x] レビュー
- [x] パッチバージョンアップ

