### PR TITLE
sitemap は noindex ページを含まない

### DIFF
--- a/lib/init.php
+++ b/lib/init.php
@@ -11,7 +11,7 @@
 // PukiWiki version / Copyright / Licence
 
 define('S_VERSION', '1.4.7');
-define('QHM_VERSION', '7.2.5');  //絶対に編集しないで下さい
+define('QHM_VERSION', '7.2.6');  //絶対に編集しないで下さい
 define('QHM_OPTIONS', 'update=download; support=false; banner=true');
 define('S_COPYRIGHT',
 	'powered by <strong><a href="https://haik-cms.jp/">HAIK</a> ' . QHM_VERSION . '</strong><br />' .

--- a/plugin/sitemap.inc.php
+++ b/plugin/sitemap.inc.php
@@ -28,7 +28,7 @@ define('PLUGIN_SITEMAP_READ_PAGES', true);
 
 define('PLUGIN_SITEMAP_PLUGIN_PRIORITY_UP',   '(counter)');
 define('PLUGIN_SITEMAP_PLUGIN_PRIORITY_DOWN', '(norelated)');
-define('PLUGIN_SITEMAP_PLUGIN_NO_FOLLOW',     '(nofollow)');
+define('PLUGIN_SITEMAP_PLUGIN_NO_FOLLOW',     '(nofollow|secret)');
 
 define('PLUGIN_SITEMAP_PAGE_ALLOW',    '');
 define('PLUGIN_SITEMAP_PAGE_DISALLOW', '^(Pukiwiki\/.*)$');

--- a/plugin/sitemap.inc.php
+++ b/plugin/sitemap.inc.php
@@ -95,6 +95,8 @@ function plugin_sitemap_action() {
 						} elseif (preg_match('/&([^\(]+)(?:\((.*)\))?;/', $line, $matches)) {
 							if ( (PLUGIN_SITEMAP_PLUGIN_PRIORITY_UP   != '') and preg_match('/^' . PLUGIN_SITEMAP_PLUGIN_PRIORITY_UP   . '$/', $matches[1], $matches2) ) $_priority += 0.2;
 							if ( (PLUGIN_SITEMAP_PLUGIN_PRIORITY_DOWN != '') and preg_match('/^' . PLUGIN_SITEMAP_PLUGIN_PRIORITY_DOWN . '$/', $matches[1], $matches2) ) $_priority -= 0.1;
+						} elseif (preg_match('/^NOINDEX:(?:.*)$/', $line)) {
+							$show = false;
 						}
 					}
 				}


### PR DESCRIPTION
## 概要
Close #119 
- `NOINDEX:` を記述したページを sitemap に含めないようにした
- `#secret` を記述したページを sitemap に含まないようにした

## テスト方法

1. 新しいページAを作る
2. サイトマップ `index.php?cmd=sitemap` を確認、ページAが含まれていることを確認する
3. ページAを noindex にする
4. サイトマップ `index.php?cmd=sitemap` を確認、ページAが含まれていないことを確認する
5. 新しいページBを作る
6. サイトマップ `index.php?cmd=sitemap` を確認、ページBが含まれていることを確認する
7. ページBに `#secret(password)` を設置する
8. サイトマップ `index.php?cmd=sitemap` を確認、ページBが含まれていないことを確認する

## タスク

- [x] レビュー
- [x] パッチバージョンアップ
