### PR TITLE
Update FontAwesome to v5.1.0

### DIFF
--- a/plugin/icon.inc.php
+++ b/plugin/icon.inc.php
@@ -73,8 +73,8 @@ function plugin_icon_set_font_awesome($search_pseudo_elements = false)
 {
 	$qt = get_qt();
 	$js = <<<HTML
-<script defer src="https://use.fontawesome.com/releases/v5.0.9/js/all.js"></script>
-<script defer src="https://use.fontawesome.com/releases/v5.0.9/js/v4-shims.js"></script>
+<script defer src="https://use.fontawesome.com/releases/v5.1.0/js/all.js"></script>
+<script defer src="https://use.fontawesome.com/releases/v5.1.0/js/v4-shims.js"></script>
 HTML;
     // CSS Pseudo-elements を利用する場合
     if ($search_pseudo_elements) {


### PR DESCRIPTION
## 概要
Close #121 
- FontAwesome を `v5.0.9` → `v5.1.0` へアップデート
- `icon` プラグインで利用できるアイコンが増えた

## テスト方法

`v5.1.0` で追加されたアイコンが利用できればOK
例： `&icon(bed);` 

## タスク

- [ ] レビュー
- [ ] パッチバージョンアップ
- [ ] マージ