### PR TITLE
シェアボタンからGoogle+を削除

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ version: 2
 jobs:
   build:
     docker:
-      - image: circleci/php:7.1.5-browsers
+      - image: circleci/php:7.3.4-apache
     working_directory: ~/repo
     steps:
       - checkout

--- a/lib/init.php
+++ b/lib/init.php
@@ -11,7 +11,7 @@
 // PukiWiki version / Copyright / Licence
 
 define('S_VERSION', '1.4.7');
-define('QHM_VERSION', '7.3.0');  //絶対に編集しないで下さい
+define('QHM_VERSION', '7.3.1');  //絶対に編集しないで下さい
 define('QHM_OPTIONS', 'update=download; support=false; banner=true');
 define('S_COPYRIGHT',
 	'powered by <strong><a href="https://haik-cms.jp/">HAIK</a> ' . QHM_VERSION . '</strong><br />' .

--- a/plugin/qblog/qblog_index_template.html
+++ b/plugin/qblog/qblog_index_template.html
@@ -416,7 +416,7 @@ $(function(){
 							<tbody>
 								<tr>
 									<td><label class="radio"><input type="radio" name="qblog_social_widget" id="" value="default" />
-										<b>標準</b>：Twitter, Facebook, Google+ のボタンを表示する。
+										<b>標準</b>：Twitter, Facebook のボタンを表示する。
 									</label></td>
 								</tr>
 								<tr>

--- a/plugin/share_buttons.inc.php
+++ b/plugin/share_buttons.inc.php
@@ -11,26 +11,24 @@
  *   modified :
  *
  *   Description
- *   
- *   
+ *
+ *
  *   Usage :
- *   
+ *
  */
 
 define('PLUGIN_SHARE_BUTTONS_FACEBOOK', '<a href="http://www.facebook.com/share.php?u=%3$s" class="facebook" onclick="window.open(this.href, \'FBwindow\', \'width=650, height=450, menubar=no, toolbar=no, scrollbars=yes\'); return false;" title="%5$s"><i class="fa fa-2x fa-facebook-square"></i><span class="sr-only">%5$s</span></a>');
 
 define('PLUGIN_SHARE_BUTTONS_TWITTER', '<a href="http://twitter.com/share?url=%3$s&text=%4$s" class="twitter" onclick="window.open(this.href, \'tweetwindow\', \'width=550, height=450,personalbar=0,toolbar=0,scrollbars=1,resizable=1\'); return false;" title="%5$s"><i class="fa fa-2x fa-twitter-square"></i><span class="sr-only">%5$s</span></a>');
 
-define('PLUGIN_SHARE_BUTTONS_GOOGLE_PLUS', '<a href="https://plus.google.com/share?url=%3$s" class="google-plus" onclick="window.open(this.href, \'Gwindow\', \'width=650, height=450, menubar=no, toolbar=no, scrollbars=yes\'); return false;" title="%5$s"><i class="fa fa-2x fa-google-plus-square"></i><span class="sr-only">%5$s</span></a>');
- 
 function plugin_share_buttons_convert()
 {
 	global $script, $vars;
 	global $defaultpage, $site_title, $site_title_delim;
-	
+
 	$qt = get_qt();
-	
-	
+
+
 	$buttons_options = array(
 		'facebook' => array(
 			'title' => 'Facebook でシェア',
@@ -38,17 +36,14 @@ function plugin_share_buttons_convert()
 		'twitter' => array(
 			'title' => 'Twitter でシェア',
 		),
-		'google_plus' => array(
-			'title' => 'Google+ でシェア',
-		),
 	);
-	
+
 	if (exist_plugin('icon'))
 	{
     	plugin_icon_set_font_awesome();
 	}
-	
-	
+
+
 	$buttons = array();
 	$align = 'left';
 	$nav = false;
@@ -65,15 +60,6 @@ function plugin_share_buttons_convert()
 			case 'tw':
 			case 'twitter':
 				$buttons['twitter'] = $buttons_options['twitter'];
-				break;
-			case 'gp':
-			case 'gplus':
-			case 'google-plus':
-			case 'google_plus':
-			case 'googleplus':
-			case 'plus':
-			case 'g+':
-				$buttons['google_plus'] = $buttons_options['google_plus'];
 				break;
 			case 'left':
 			case 'right':
@@ -95,7 +81,7 @@ function plugin_share_buttons_convert()
 	$page_title = get_page_title($vars['page']);
 	$full_title = ($vars['page'] === $defaultpage) ? $page_title : ($page_title . $site_title_delim . $site_title);
 	$enc_full_title = rawurlencode($full_title);
-	
+
 	$share_buttons = array_keys($buttons);
 
     $navclass = $nav ? ' share_buttons_nav navbar-text' : '';
@@ -108,9 +94,9 @@ function plugin_share_buttons_convert()
 		{
 			$html .= '<li>' . sprintf(constant($defname), h($url), h($full_title), h($enc_url), h($enc_full_title), h($title)) . '</li>';
 		}
-	}	
+	}
 	$html .= '</ul></div>';
-	
+
 	$addstyle = '
 <style>
 .share_buttons {
@@ -153,28 +139,20 @@ function plugin_share_buttons_convert()
   border-radius: 7px;
   max-height: 24px;
 }
-.share_buttons ul.nav > li > a i.orgm-icon-google-plus-2:before {
-  background-color: white;
-  border-radius: 7px;
-  max-height: 24px;
-}
 .share_buttons ul.nav > li > a.facebook:hover > i {
   color: #3b5998;
 }
 .share_buttons ul.nav > li > a.twitter:hover > i {
   color: #3fbdf6;
 }
-.share_buttons ul.nav > li > a.google-plus:hover > i {
-  color: #d34836;
-}
 </style>
 ';
-	
+
 	$qt->appendv_once('plugin_share_button_style', 'beforescript', $addstyle);
-	
-	
+
+
 	//$qt->setv('share_buttons', $html);
-	
+
 	return $html;
 }
 

--- a/plugin/social_buttons.inc.php
+++ b/plugin/social_buttons.inc.php
@@ -32,7 +32,7 @@ function plugin_social_buttons_convert()
 	$text = ''; //extra text
 	$float = 'right'; //left|right
 
-	$service_list = array('google_plusone', 'twitter', 'facebook_like');
+	$service_list = array('twitter', 'facebook_like');
 
 	$services = array();
 	foreach ($args as $arg)
@@ -48,11 +48,6 @@ function plugin_social_buttons_convert()
 		{
 			$option_str = isset($mts[1]) ? $mts[1] : '';
 			$services['facebook_like'] = plugin_social_buttons_parse_option($option_str);
-		}
-		else if (preg_match('/^(?:google_plusone|gp)(?:=([^,\)]*))?$/', $arg, $mts))
-		{
-			$option_str = isset($mts[1]) ? $mts[1] : '';
-			$services['google_plusone'] = plugin_social_buttons_parse_option($option_str);
 		}
 		else if (in_array($arg, array('h1', 'h2', 'large')))
 		{
@@ -130,25 +125,6 @@ function plugin_social_buttons_convert()
 				$option['show_faces'] ='false';
 				$option['layout'] = $tmp;
 				$option['width'] = isset($option['width']) ? $option['width'] : $width;
-				break;
-			case 'google_plusone':
-				$count = TRUE;
-				//size
-				switch ($layout)
-				{
-					case 'h1':
-						$count = 'false';
-					case 'h2':
-						$tmp = 'medium';
-						break;
-					default: //large
-						$tmp = 'tall';
-				}
-				$option['size'] = $tmp;
-				$option['count'] = $count;
-
-				//lang
-				$option['lang'] = 'ja';
 				break;
 		}
 


### PR DESCRIPTION
Close #127 

- ブログ設定から文言を削除
    ![スクリーンショット 2019-06-26 23 22 43](https://user-images.githubusercontent.com/808888/60187995-8ca32180-9869-11e9-8795-87ad14ea1c9e.png)
- `#share_buttons` から Google+ を削除
    ![スクリーンショット 2019-06-26 23 23 09](https://user-images.githubusercontent.com/808888/60187997-8ca32180-9869-11e9-8700-407dec8578ed.png)
- `#social_buttons` （ブログ記事に自動的に設置されるもの）からGoogle+を削除
    ![スクリーンショット 2019-06-26 23 23 03](https://user-images.githubusercontent.com/808888/60187998-8d3bb800-9869-11e9-9245-ddee2166081d.png)
