### PR TITLE
PHP7.3でQBlog記事の編集画面が通常ページの編集画面になる不具合を修正

### DIFF
--- a/lib/func.php
+++ b/lib/func.php
@@ -129,7 +129,8 @@ function is_qblog($page = NULL)
 		'YYYY' => '\d{4}',
 		'MM'   => '\d{2}',
 		'DD'   => '\d{2}',
-		'#'    => '\d+',
+		'\#'   => '\d+', // PHP7.3 対応 @see https://www.php.net/manual/ja/migration73.other-changes.php#migration73.other-changes.pcre
+		'#'    => '\d+'  // PHP7.2 以下対応
 	);
 	$re = preg_quote($qblog_page_format);
 	$re = str_replace(

--- a/lib/init.php
+++ b/lib/init.php
@@ -11,7 +11,7 @@
 // PukiWiki version / Copyright / Licence
 
 define('S_VERSION', '1.4.7');
-define('QHM_VERSION', '7.3.3');  //絶対に編集しないで下さい
+define('QHM_VERSION', '7.3.4');  //絶対に編集しないで下さい
 define('QHM_OPTIONS', 'update=download; support=false; banner=true');
 define('S_COPYRIGHT',
 	'powered by <strong><a href="https://haik-cms.jp/">HAIK</a> ' . QHM_VERSION . '</strong><br />' .


### PR DESCRIPTION
PHP7.3から `#` がpreg_quoteでエスケープされるようになったため発生していた。

Fix #132 