### PR TITLE
[PHP7.3]QBlogで同じ日に記事が2つ以上書けない問題を修正

### DIFF
--- a/lib/file.php
+++ b/lib/file.php
@@ -1669,7 +1669,8 @@ function qblog_get_newpage($date = NULL)
 		$filename_prefix = encode(substr($newpage, 0, $number_holder_pos));
 		$files = glob(DATA_DIR . $filename_prefix . '*');
 		
-		$pattern = '/^(' . str_replace('#', '(\d+)', preg_quote($newpage)) . ')$/';
+		// PHP7.3 より正規表現において # が特殊文字として扱われる
+		$pattern = '/^(' . str_replace(['\#', '#'], '(\d+)', preg_quote($newpage)) . ')$/';
 		$max = 0;
 		foreach ($files as $file)
 		{

--- a/lib/init.php
+++ b/lib/init.php
@@ -11,7 +11,7 @@
 // PukiWiki version / Copyright / Licence
 
 define('S_VERSION', '1.4.7');
-define('QHM_VERSION', '7.3.6');  //絶対に編集しないで下さい
+define('QHM_VERSION', '7.3.7');  //絶対に編集しないで下さい
 define('QHM_OPTIONS', 'update=download; support=false; banner=true');
 define('S_COPYRIGHT',
 	'powered by <strong><a href="https://haik-cms.jp/">HAIK</a> ' . QHM_VERSION . '</strong><br />' .


### PR DESCRIPTION
Close #139 

記事のナンバリングに使っていた `#` が PHP7.3 より正規表現の特殊文字として扱われるようになり、 `preg_quote` によりバックスラッシュが付与されるようになったため、置換処理に失敗していた。
バックスラッシュが有ってもなくても成功するように修正した。