### PR TITLE
メールにファイル名が日本語のファイルを添付すると文字化けする問題を修正

### DIFF
--- a/lib/init.php
+++ b/lib/init.php
@@ -11,7 +11,7 @@
 // PukiWiki version / Copyright / Licence
 
 define('S_VERSION', '1.4.7');
-define('QHM_VERSION', '7.3.7');  //絶対に編集しないで下さい
+define('QHM_VERSION', '7.3.8');  //絶対に編集しないで下さい
 define('QHM_OPTIONS', 'update=download; support=false; banner=true');
 define('S_COPYRIGHT',
 	'powered by <strong><a href="https://haik-cms.jp/">HAIK</a> ' . QHM_VERSION . '</strong><br />' .

--- a/lib/simplemail.php
+++ b/lib/simplemail.php
@@ -368,7 +368,8 @@ Content-Transfer-Encoding: '.$encoding.'
 	 */
 	function mime($str = '', $mail_encode = 'ISO-2022-JP') {
 		mb_internal_encoding($mail_encode);
-		$str = mb_encode_mimeheader($str, $mail_encode, $this->encoding);
+		$str = mb_convert_encoding($str, $mail_encode, $this->encoding);
+		$str = mb_encode_mimeheader($str, $mail_encode, 'B');
 		mb_internal_encoding($this->encoding);
 
 		return $str;

--- a/lib/simplemail.php
+++ b/lib/simplemail.php
@@ -239,6 +239,7 @@ class SimpleMail{
 		}
 
 		$body = str_replace("\r", "", $body);
+		$body = $this->normalize($body);
 		$body = mb_convert_kana($body, "KV");
 		$body = mb_convert_encoding($body, $mail_encode, $this->encoding);
 
@@ -362,16 +363,21 @@ Content-Transfer-Encoding: '.$encoding.'
 		return $ret;
 	}
 
+	// 濁点付きの文字が2文字扱いにならないよう合成する
+	function normalize($str) {
+		if (class_exists('Normalizer')) {
+			$str = Normalizer::normalize($str, Normalizer::FORM_C);
+		}
+		return $str;
+	}
+
 	/**
 	 *   内部エンコードを変えて、mb_encode_mimeheader() をかける
 	 *   長い差し出し人名などに対応（長すぎると消える）
 	 */
 	function mime($str = '', $mail_encode = 'ISO-2022-JP') {
 		mb_internal_encoding($mail_encode);
-		// 濁点付きの文字が2文字扱いにならないよう合成する
-		if (class_exists('Normalizer')) {
-			$str = Normalizer::normalize($str, Normalizer::FORM_C);
-		}
+		$str = $this->normalize($str);
 		$str = mb_convert_encoding($str, $mail_encode, $this->encoding);
 		$str = mb_encode_mimeheader($str, $mail_encode, 'B');
 		mb_internal_encoding($this->encoding);

--- a/lib/simplemail.php
+++ b/lib/simplemail.php
@@ -368,6 +368,10 @@ Content-Transfer-Encoding: '.$encoding.'
 	 */
 	function mime($str = '', $mail_encode = 'ISO-2022-JP') {
 		mb_internal_encoding($mail_encode);
+		// 濁点付きの文字が2文字扱いにならないよう合成する
+		if (class_exists('Normalizer')) {
+			$str = Normalizer::normalize($str, Normalizer::FORM_C);
+		}
 		$str = mb_convert_encoding($str, $mail_encode, $this->encoding);
 		$str = mb_encode_mimeheader($str, $mail_encode, 'B');
 		mb_internal_encoding($this->encoding);


### PR DESCRIPTION
## 概要
- OSX のファインダーからファイル名が日本語のファイルを添付するとメールクライアントで閲覧時に文字化けすることがある
- カタカナの濁点や半濁点の合字が問題だったので正規化することで対応
