### PR TITLE
iconプラグインをBootstrap Iconsに対応させる

### DIFF
--- a/lib/init.php
+++ b/lib/init.php
@@ -11,7 +11,7 @@
 // PukiWiki version / Copyright / Licence
 
 define('S_VERSION', '1.4.7');
-define('QHM_VERSION', '7.3.9');  //絶対に編集しないで下さい
+define('QHM_VERSION', '7.4.0');  //絶対に編集しないで下さい
 define('QHM_OPTIONS', 'update=download; support=false; banner=true');
 define('S_COPYRIGHT',
 	'powered by <strong><a href="https://haik-cms.jp/">HAIK</a> ' . QHM_VERSION . '</strong><br />' .

--- a/plugin/icon.inc.php
+++ b/plugin/icon.inc.php
@@ -49,6 +49,13 @@ function plugin_icon_inline()
 		{
 			$icon_options = " {$icon_prefix}{$arg}";
 		}
+		// Bootstrap Icons
+		else if ($arg === 'bootstrap-icons' OR $arg === 'bi')
+		{
+			$icon_base = 'bi';
+			$icon_prefix = $icon_base . '-';
+			plugin_icon_set_bootstrap_icons();
+		}
 		else if ($arg !== '')
 		{
 			$icon_name = $arg;
@@ -86,4 +93,13 @@ HTML;
         $qt->prependv_once('plugin_icon_font_awesome_pseudo_elements', 'beforescript', $extrajs);
     }
 	$qt->appendv_once('plugin_icon_font_awesome', 'beforescript', $js);
+}
+
+function plugin_icon_set_bootstrap_icons()
+{
+	$qt = get_qt();
+	$head = <<<HTML
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.8.1/font/bootstrap-icons.css">
+HTML;
+	$qt->appendv_once('plugin_icon_bootstrap_icons', 'beforescript', $head);
 }


### PR DESCRIPTION
## 概要
- `icon`プラグインで[Bootstrap Icons](https://icons.getbootstrap.com/)を利用できるように機能追加

## 使い方

`bi`を指定した後にアイコン名を指定する。

[`arrow-right-circle`](https://icons.getbootstrap.com/icons/arrow-right-circle/)の場合
```
&icon(bi,arrow-right-circle);
```

<img width="46" alt="スクリーンショット 2022-02-19 13 56 25" src="https://user-images.githubusercontent.com/808888/154786837-b282f12e-fdb0-4941-bdca-ac4bbb478dd0.png">

