### PR TITLE
clickpadプロンプト起動中にショートカットが暴発しないよう修正

### DIFF
--- a/js/jquery.clickpad.js
+++ b/js/jquery.clickpad.js
@@ -1965,7 +1965,8 @@ $(document).ready(function(){
 				.html('<label>'+$$.html()+'</label>')
 					.find("input.cp_popup_prompt")
 					.width(inputWidth)
-					.val(opt.defval);
+					.val(opt.defval)
+					.on('keydown', (e) => { e.stopPropagation() });
 			}
 
 			var css = opt.css || {};

--- a/lib/init.php
+++ b/lib/init.php
@@ -11,7 +11,7 @@
 // PukiWiki version / Copyright / Licence
 
 define('S_VERSION', '1.4.7');
-define('QHM_VERSION', '7.4.0');  //絶対に編集しないで下さい
+define('QHM_VERSION', '7.4.1');  //絶対に編集しないで下さい
 define('QHM_OPTIONS', 'update=download; support=false; banner=true');
 define('S_COPYRIGHT',
 	'powered by <strong><a href="https://haik-cms.jp/">HAIK</a> ' . QHM_VERSION . '</strong><br />' .


### PR DESCRIPTION
## 概要
装飾時などに使うプロンプト（モーダル）でテキスト入力欄にhaikショートカットが存在する文字列を入力するとショートカットが暴発してしまう問題を修正しました。

例えば、 `n` を入力すると新規ページ作成画面に行ってしまうといった挙動を修正しています。
画像は `n` が入力できるようになったスクショです。
![スクリーンショット 2022-05-12 22 50 04](https://user-images.githubusercontent.com/808888/168090876-69a6bd81-eb5e-4a10-a961-bd43a035cba0.png)

