### PR TITLE
iconプラグインで Google Material Symbols を利用可能にした

### DIFF
--- a/js/jquery.clickpad.js
+++ b/js/jquery.clickpad.js
@@ -790,9 +790,18 @@ $(document).ready(function(){
 						type: 'text',
 						inputWidthRatio: 1,
 						css:{clear:"both"}
+					}},
+					{msg:'<span style="color:#2C48BF">文字色</span>を入力してください',option:{
+						type: 'text',
+						inputWidthRatio: 0.3,
+						css:{clear:"both"}
+					}},
+					{msg:'文字サイズ<span style="font-size:11px">（数値、単位付き指定（ex:2em）、small、largeなど）</span>',option:{
+						type: 'text',
+						inputWidthRatio: 0.3
 					}}
 				],
-				'&icon(${1});']
+				'&deco(${2},${3}){&icon(${1});};']
 		},
     'haikOl': {
       caption: '番号付き箇条書き',

--- a/js/jquery.clickpad.js
+++ b/js/jquery.clickpad.js
@@ -786,9 +786,9 @@ $(document).ready(function(){
 			func: 'cpDialog',
 			value: [
 				[
-					{msg:'アイコン用HTMLを入力してください（Google Material Icons に対応）',option:{
+					{msg:'アイコン用HTMLを入力してください。<br /><strong>対応アイコン</strong><ul style="margin-bottom: 10px"><li><a href="https://fonts.google.com/icons" target="_blank">Google Material Icons</a></li></ul>',option:{
 						type: 'text',
-						inputWidthRatio: 1,
+						inputWidthRatio: 0.9,
 						css:{clear:"both"}
 					}},
 					{msg:'<span style="color:#2C48BF">文字色</span>を入力してください',option:{

--- a/js/jquery.clickpad.js
+++ b/js/jquery.clickpad.js
@@ -780,6 +780,20 @@ $(document).ready(function(){
 			func: 'cpInsert',
 			value: '&show(,,画像の説明);'
 		},
+		'haikIcon': {
+			caption: 'アイコン',
+			classAttribute: 'qhm-btn qhm-btn-default qhm-btn-sm',
+			func: 'cpDialog',
+			value: [
+				[
+					{msg:'アイコン用HTMLを入力してください（Google Material Icons に対応）',option:{
+						type: 'text',
+						inputWidthRatio: 1,
+						css:{clear:"both"}
+					}}
+				],
+				'&icon(${1});']
+		},
     'haikOl': {
       caption: '番号付き箇条書き',
       classAttribute: 'qhm-btn qhm-btn-default qhm-btn-sm',
@@ -1339,7 +1353,7 @@ $(document).ready(function(){
 		],
 
 		qhmHaik : [
-			['haikHeader', 'haikB', 'haikHandline', 'haikDecop', 'haikBr', 'haikHr', 'haikLink', 'haikUl', 'haikLeft', 'haikCenter', 'haikRight', 'haikAttach', 'haikColors', 'haikParts']
+			['haikHeader', 'haikB', 'haikHandline', 'haikDecop', 'haikBr', 'haikHr', 'haikLink', 'haikUl', 'haikLeft', 'haikCenter', 'haikRight', 'haikIcon', 'haikAttach', 'haikColors', 'haikParts']
 		],
 
 		//QBlog
@@ -1352,7 +1366,7 @@ $(document).ready(function(){
 			['green', 'lime', 'lightgreen', 'purple', 'magenta', 'pink', 'red', 'orange', 'yellow']
 		],
 		qhmHaikQBlog : [
-			['haikHeader', 'haikB', 'haikHandline', 'haikDecop', 'haikBr', 'haikHr', 'haikLink', 'haikUl', 'haikLeft', 'haikCenter', 'haikRight', 'haikAttach'],
+			['haikHeader', 'haikB', 'haikHandline', 'haikDecop', 'haikBr', 'haikHr', 'haikLink', 'haikUl', 'haikLeft', 'haikCenter', 'haikRight', 'haikIcon', 'haikAttach'],
 			['haikColors', 'haikParts']
 		],
 

--- a/plugin/icon.inc.php
+++ b/plugin/icon.inc.php
@@ -25,6 +25,11 @@ function plugin_icon_inline()
 	$icon_prefix = $icon_base . '-';
 	$icon_name = $icon_options = '';
 
+	if (isset($args[0]) && preg_match('/^<span class="material-symbols-(outlined|rounded|sharp)">(.+)<\/span>$/', $args[0], $matches)) {
+		plugin_icon_set_google_material_icons($matches[1]);
+		return $args[0];
+	}
+
 	foreach ($args as $arg)
 	{
 		if ($arg === 'glyphicon')
@@ -102,4 +107,20 @@ function plugin_icon_set_bootstrap_icons()
 <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.8.1/font/bootstrap-icons.css">
 HTML;
 	$qt->appendv_once('plugin_icon_bootstrap_icons', 'beforescript', $head);
+}
+
+function plugin_icon_set_google_material_icons($type) {
+	$type_capitalized = ucfirst($type);
+	$qt = get_qt();
+	$head = <<<HTML
+<link href="https://fonts.googleapis.com/css2?family=Material+Symbols+$type_capitalized:opsz,wght,FILL,GRAD@20..48,100..700,0..1,-50..200" rel="stylesheet" />
+<style>
+.material-symbols-$type {
+  display: inline-flex;
+  vertical-align: middle;
+	font-size: inherit;
+}
+</style>
+HTML;
+	$qt->appendv_once("plugin_icon_google_material_icons_$type", 'beforescript', $head);
 }

--- a/plugin/icon.inc.php
+++ b/plugin/icon.inc.php
@@ -24,6 +24,9 @@ function plugin_icon_inline()
 	$icon_base = 'glyphicon';
 	$icon_prefix = $icon_base . '-';
 	$icon_name = $icon_options = '';
+	$icon_text = '';
+
+	$format = '<i class="%s %s%s" aria-hidden="true"></i>';
 
 	if (isset($args[0]) && preg_match('/^<span class="material-symbols-(outlined|rounded|sharp)">(.+)<\/span>$/', $args[0], $matches)) {
 		plugin_icon_set_google_material_icons($matches[1]);
@@ -61,6 +64,17 @@ function plugin_icon_inline()
 			$icon_prefix = $icon_base . '-';
 			plugin_icon_set_bootstrap_icons();
 		}
+		// Google Material Symbols
+		else if (preg_match('/^gms(o|r|s)$/', $arg, $mts)) {
+			$map = [
+				"o" => "outlined",
+				"r" => "rounded",
+				"s" => "sharp"
+			];
+			$icon_base = 'material-symbols-' . $map[$mts[1]];
+			$icon_prefix = '';
+			$format = '<i class="%s">%s</i>';
+		}
 		else if ($arg !== '')
 		{
 			$icon_name = $arg;
@@ -69,7 +83,6 @@ function plugin_icon_inline()
 
 	$icon_name = $icon_prefix.$icon_name;
 
-	$format = '<i class="%s %s%s" aria-hidden="true"></i>';
 	return sprintf($format, h($icon_base), h($icon_name), $icon_options);
 }
 


### PR DESCRIPTION
## 概要
icon プラグインを拡張し、 [Google Material Symbils](https://fonts.google.com/icons)を利用できるようにしました。

## 書式
HTML直接添付と従来の方式の2種類あります。

### HTML直接添付方式

アイコン一覧から利用するアイコンを探してサンプルをコピーし、 `&icon();` で囲むことですぐに利用できます。

```
&icon(<span class="material-symbols-outlined">search</span>);
```

上記のように、アイコンページでコピーできるHTMLを `&icon(` `);` で囲みます。
コピーできるHTMLには改行が含まれているため利用する際に改行を除去する必要があります。
iconプラグインはインラインプラグインのためです。

後述の clickpad の拡張により貼り付け作業を簡易にしています。


### 従来方式

```
&icon(gmso,search);
```

Google Material Symbols の頭文字を取って `gms` 、字体のバリエーションの `outlined` `rounded` `sharp` の頭文字を取って `o` `r` `s` のいずれかを続けます。
`gmso` → `outlined` のアイコンが表示されます。

字体やアイコン名を覚えている人はこちらの方が早く入力することができます。

## clickpad の拡張

おもにアイコンをHTMLのコピー＆ペーストで行いたい人向けに clickpad を拡張しています。
画像挿入ボタンの横にアイコン挿入ボタンを追加しました。
![スクリーンショット 2022-06-17 23 50 20](https://user-images.githubusercontent.com/808888/174322409-93572e8f-6523-4c84-bba9-38a9fca09ebe.png)

![スクリーンショット 2022-06-17 23 51 04](https://user-images.githubusercontent.com/808888/174322427-fd7c108d-0dd3-4137-8cc3-f4f7026b15a5.png)
このボタンをクリックすることでアイコンのHTML入力欄が表示されます。

![スクリーンショット 2022-06-17 23 44 29](https://user-images.githubusercontent.com/808888/174321081-54ef8ec3-ec65-4b50-bd02-3288ffac5742.png)
コピーしたHTMLをペーストすると改行が除去された状態になりますので、「OK」ボタンを押すことでiconプラグインの書式が本文入力欄へ挿入されます。


同時に文字色、文字サイズを変更することができるようになっています。
