### PR TITLE
iconプラグインで Google Material Icons を利用可能にした

### DIFF
--- a/js/jquery.clickpad.js
+++ b/js/jquery.clickpad.js
@@ -786,7 +786,7 @@ $(document).ready(function(){
 			func: 'cpDialog',
 			value: [
 				[
-					{msg:'アイコン用HTMLを入力してください。<br /><strong>対応アイコン</strong><ul style="margin-bottom: 10px"><li><a href="https://fonts.google.com/icons" target="_blank">Google Material Icons</a></li></ul>',option:{
+					{msg:'アイコン用HTMLを入力してください。<br /><strong>対応アイコン</strong><ul style="margin-bottom: 10px"><li><a href="https://fonts.google.com/icons?icon.set=Material+Icons" target="_blank">Google Material Icons</a></li><li><a href="https://fonts.google.com/icons" target="_blank">Google Material Symbols</a></li></ul>',option:{
 						type: 'text',
 						inputWidthRatio: 0.9,
 						css:{clear:"both"}

--- a/lib/init.php
+++ b/lib/init.php
@@ -11,7 +11,7 @@
 // PukiWiki version / Copyright / Licence
 
 define('S_VERSION', '1.4.7');
-define('QHM_VERSION', '7.5.0');  //絶対に編集しないで下さい
+define('QHM_VERSION', '7.6.0');  //絶対に編集しないで下さい
 define('QHM_OPTIONS', 'update=download; support=false; banner=true');
 define('S_COPYRIGHT',
 	'powered by <strong><a href="https://haik-cms.jp/">HAIK</a> ' . QHM_VERSION . '</strong><br />' .

--- a/plugin/icon.inc.php
+++ b/plugin/icon.inc.php
@@ -32,6 +32,11 @@ function plugin_icon_inline()
 		plugin_icon_set_google_material_symbols($matches[1]);
 		return $args[0];
 	}
+	if (isset($args[0]) && preg_match('/^<span class="material-icons(?:-(outlined|round|sharp|two-tone))?">\s*(\w+)\s*<\/span>$/', $args[0], $matches)) {
+		$type = isset($matches[1]) ? $matches[1] : 'filled';
+		plugin_icon_set_google_material_icons($type);
+		return $args[0];
+	}
 
 	foreach ($args as $arg)
 	{
@@ -131,6 +136,30 @@ function plugin_icon_set_google_material_symbols($type) {
 <link href="https://fonts.googleapis.com/css2?family=Material+Symbols+$type_capitalized:opsz,wght,FILL,GRAD@20..48,100..700,0..1,-50..200" rel="stylesheet" />
 <style>
 .material-symbols-$type {
+  display: inline-flex;
+  vertical-align: middle;
+	font-size: inherit;
+}
+</style>
+HTML;
+	$qt->appendv_once("plugin_icon_google_material_symbols_$type", 'beforescript', $head);
+}
+
+function plugin_icon_set_google_material_icons($type) {
+	$map = [
+		"outlined" => "+Outlined",
+		"filled" => "",
+		"round" => "+Round",
+		"sharp" => "+Sharp",
+		"two-tone" => "+Two+Tone"
+	];
+	$additional_query = $map[$type];
+	$qt = get_qt();
+	$head = <<<HTML
+<link href="https://fonts.googleapis.com/icon?family=Material+Icons$additional_query" rel="stylesheet">
+<style>
+.material-icons,
+.material-icons-$type {
   display: inline-flex;
   vertical-align: middle;
 	font-size: inherit;

--- a/plugin/icon.inc.php
+++ b/plugin/icon.inc.php
@@ -82,6 +82,21 @@ function plugin_icon_inline()
 			$format = '<i class="%s">%s</i>';
 			plugin_icon_set_google_material_symbols($type);
 		}
+		// Google Material Icons
+		else if (preg_match('/^gmi(o|f|r|s|tt)$/', $arg, $mts)) {
+			$map = [
+				"o" => "outlined",
+				"f" => "filled",
+				"r" => "round",
+				"s" => "sharp",
+				"tt" => "two-tone"
+			];
+			$type = $map[$mts[1]];
+			$icon_base = $type === 'filled' ? 'material-icons' : 'material-icons-' . $type;
+			$icon_prefix = '';
+			$format = '<i class="%s">%s</i>';
+			plugin_icon_set_google_material_icons($type);
+		}
 		else if ($arg !== '')
 		{
 			$icon_name = $arg;

--- a/plugin/icon.inc.php
+++ b/plugin/icon.inc.php
@@ -29,7 +29,7 @@ function plugin_icon_inline()
 	$format = '<i class="%s %s%s" aria-hidden="true"></i>';
 
 	if (isset($args[0]) && preg_match('/^<span class="material-symbols-(outlined|rounded|sharp)">\s*(\w+)\s*<\/span>$/', $args[0], $matches)) {
-		plugin_icon_set_google_material_icons($matches[1]);
+		plugin_icon_set_google_material_symbols($matches[1]);
 		return $args[0];
 	}
 
@@ -75,7 +75,7 @@ function plugin_icon_inline()
 			$icon_base = 'material-symbols-' . $type;
 			$icon_prefix = '';
 			$format = '<i class="%s">%s</i>';
-			plugin_icon_set_google_material_icons($type);
+			plugin_icon_set_google_material_symbols($type);
 		}
 		else if ($arg !== '')
 		{
@@ -124,7 +124,7 @@ HTML;
 	$qt->appendv_once('plugin_icon_bootstrap_icons', 'beforescript', $head);
 }
 
-function plugin_icon_set_google_material_icons($type) {
+function plugin_icon_set_google_material_symbols($type) {
 	$type_capitalized = ucfirst($type);
 	$qt = get_qt();
 	$head = <<<HTML


### PR DESCRIPTION
## 概要
icon プラグインを拡張し、 [Google Material Icons](https://fonts.google.com/icons?icon.set=Material+Icons)を利用できるようにしました。

![スクリーンショット 2022-06-25 11 34 02](https://user-images.githubusercontent.com/808888/175755161-fe094d88-01e0-4961-ad52-0d643cd78516.png)


## 書式
HTML直接添付と従来の方式の2種類あります。

### HTML直接添付方式

アイコン一覧から利用するアイコンを探してサンプルをコピーし、 `&icon();` で囲むことですぐに利用できます。

```
&icon(<span class="material-icons">search</span>);
```

上記のように、アイコンページでコピーできるHTMLを `&icon(` `);` で囲みます。
コピーできるHTMLには改行が含まれているため利用する際に改行を除去する必要があります。
iconプラグインはインラインプラグインのためです。

#145 と同様に clickpad を拡張し、貼り付け作業を簡易にしています。


### 従来方式

```
&icon(gmio,search);
```

Google Material Icons の頭文字を取って `gmi` 、字体のバリエーションの `outlined` `filled` `round` `sharp` `two-tone` の頭文字を取って `o` `f` `r` `s` `tt` のいずれかを続けます。
`gmio` → `outlined` のアイコンが表示されます。

字体やアイコン名を覚えている人はこちらの方が早く入力することができます。


