### PR TITLE
アクセス制限対象ページへ未認証ユーザーがアクセスしたときのURLチェック処理を修正

### DIFF
--- a/lib/ss_authform.php
+++ b/lib/ss_authform.php
@@ -262,7 +262,7 @@ window.onload = function() {
  			|| location.port != '{$server_port}'
  			|| location.pathname != '{$script_name}' ) {
 
- 		var href = location.href.replace(location.search, '');
+		var href = location.href.replace(location.search, '').replace(location.hash, '');
 
  		if(! href.match(/\.php$/)){
  			href += 'index.php';


### PR DESCRIPTION
## 概要
アクセス制御を設定したページに hash fragment 付きURLでアクセスするとログイン画面に「リンクが正常に動作しないサーバーの可能性があります。」と表示されてしまう不具合を修正しました。

## 確認方法

1. アクセス制限をかけたページを用意する
2. ページ内の特定のアンカーへ向けたリンクを作成する `例： [[ページ名#アンカー名]]`
3. 上記リンクへゲストとしてアクセスする
4. ログイン画面が表示され上記メッセージが表示されなければ成功
