### PR TITLE
Bootstrap Icons のアップデート

### DIFF
--- a/lib/init.php
+++ b/lib/init.php
@@ -11,7 +11,7 @@
 // PukiWiki version / Copyright / Licence
 
 define('S_VERSION', '1.4.7');
-define('QHM_VERSION', '7.6.3');  //絶対に編集しないで下さい
+define('QHM_VERSION', '7.6.4');  //絶対に編集しないで下さい
 define('QHM_OPTIONS', 'update=download; support=false; banner=true');
 define('S_COPYRIGHT',
 	'powered by <strong><a href="https://haik-cms.jp/">HAIK</a> ' . QHM_VERSION . '</strong><br />' .

--- a/plugin/icon.inc.php
+++ b/plugin/icon.inc.php
@@ -139,7 +139,7 @@ function plugin_icon_set_bootstrap_icons()
 {
 	$qt = get_qt();
 	$head = <<<HTML
-<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.8.1/font/bootstrap-icons.css">
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.css">
 HTML;
 	$qt->appendv_once('plugin_icon_bootstrap_icons', 'beforescript', $head);
 }


### PR DESCRIPTION
Bootstrap Icons を v1.8.11 から v1.11.3 へアップデートしました。
利用できるアイコンが追加されます。

詳細は下記記事を参照してください。
https://blog.getbootstrap.com/2022/07/13/bootstrap-icons-1-9-0/
https://blog.getbootstrap.com/2022/11/11/bootstrap-icons-1-10-0/
https://blog.getbootstrap.com//2023/09/12/bootstrap-icons-1-11-0/